### PR TITLE
Reorganization of solgo path structure

### DIFF
--- a/README.md
+++ b/README.md
@@ -88,6 +88,7 @@ import (
 	"strings"
 
 	"github.com/txpull/solgo"
+	"github.com/txpull/solgo/contracts"
 )
 
 var contract = `
@@ -114,7 +115,7 @@ func main() {
 	}
 
 	// Register the contract information listener
-	contractListener := solgo.NewContractListener(parser.GetParser())
+	contractListener := contracts.NewContractListener(parser.GetParser())
 	if err := parser.RegisterListener(solgo.ListenerContractInfo, contractListener); err != nil {
 		panic(err)
 	}
@@ -172,9 +173,21 @@ import (
 	"strings"
 
 	"github.com/txpull/solgo"
+	"github.com/txpull/solgo/abis"
 )
 
-var contract = ``
+var contract = `
+// SPDX-License-Identifier: MIT
+pragma solidity ^0.8.19;
+
+contract MyContract {
+	uint256 public myUint;
+	address public myAddress;
+	string public myString = "Hello, World!";
+	bytes32 public myBytes32 = "Hello, World!";
+	bool public myBool = true;
+	uint256[] public myUintArr = [1,2,3];
+}`
 
 func main() {
 	parser, err := solgo.New(context.Background(), strings.NewReader(contract))
@@ -183,7 +196,7 @@ func main() {
 	}
 
 	// Register the abi listener
-	abiListener := solgo.NewAbiListener(parser.GetParser())
+	abiListener := abis.NewAbiListener()
 	if err := parser.RegisterListener(solgo.ListenerAbi, abiListener); err != nil {
 		panic(err)
 	}
@@ -199,13 +212,13 @@ func main() {
 	abiParser := abiListener.GetParser()
 
 	// Get JSON representation of the ABI
-	_, err := abiParser.ToJSON()
+	_, err = abiParser.ToJSON()
 	if err != nil {
 		panic(err)
 	}
 
 	// Get go-ethereum ABI representation
-	_, err := abiParser.ToABI()
+	_, err = abiParser.ToABI()
 	if err != nil {
 		panic(err)
 	}

--- a/abis/doc.go
+++ b/abis/doc.go
@@ -1,0 +1,28 @@
+// Package abis provides functionality for parsing and manipulating Solidity contract ABIs (Application Binary Interfaces).
+// It includes features for normalizing type names, parsing mapping types, handling struct types, detecting mapping and struct types,
+// and converting ABIs to JSON and Go-ethereum ABI formats.
+//
+// The package consists of several key components:
+//
+//   - The AbiListener struct is a listener for the Solidity parser that constructs an ABI as it walks the parse tree.
+//     It extends the BaseSolidityParserListener and uses an AbiParser to build the ABI.
+//
+//   - The AbiParser struct is responsible for parsing a Solidity contract ABI and converting it into an ABI object
+//     that can be easily manipulated. It maintains an internal representation of the ABI and provides methods for injecting
+//     various contract elements, such as constructors, functions, events, errors, state variables, and fallback/receive functions,
+//     into the ABI. It also handles the resolution of struct components and supports the parsing of mapping and enum types.
+//
+//   - The package includes functions for normalizing type names in Solidity to their canonical forms. For example, it can
+//     convert "uint" to "uint256" and "addresspayable" to "address".
+//
+//   - The package provides functions for detecting mapping types, struct types, and enum types in Solidity. It can determine
+//     if a given type name represents a mapping, if a type name corresponds to a defined struct, or if a type is an enumerated type.
+//
+//   - The package offers a function for parsing mapping types in Solidity ABI. It can extract the key and value types from a
+//     mapping type string of the form "mapping(keyType => valueType)".
+//
+//   - The AbiParser can convert the internal ABI representation into a JSON string or an Ethereum/go-ethereum ABI object.
+//     It provides methods for converting the ABI to these formats.
+//
+// This package is part of a larger system for working with Solidity contracts and their ABIs.
+package abis

--- a/abis/helpers.go
+++ b/abis/helpers.go
@@ -1,8 +1,10 @@
-package solgo
+package abis
 
 import (
 	"regexp"
 	"strings"
+
+	"github.com/txpull/solgo/common"
 )
 
 // normalizeTypeName normalizes the type name in Solidity to its canonical form.
@@ -23,7 +25,7 @@ func normalizeTypeName(typeName string) string {
 
 // normalizeStructTypeName normalizes the type name of a struct in Solidity to its canonical form.
 // For example, "structName[]" is normalized to "tuple[]", and "structName" is normalized to "tuple".
-func normalizeStructTypeName(definedStructs map[string]MethodIO, typeName string) string {
+func normalizeStructTypeName(definedStructs map[string]common.MethodIO, typeName string) string {
 	switch {
 	case strings.HasSuffix(typeName, "[]") && isStructType(definedStructs, strings.TrimSuffix(typeName, "[]")):
 		// Handle array of structs
@@ -42,7 +44,7 @@ func isMappingType(name string) bool {
 // isStructType checks if a type name corresponds to a defined struct.
 // definedStructs is a map from struct names to MethodIO objects representing the struct located in the AbiParser.
 // Returns true if the type name corresponds to a defined struct, false otherwise.
-func isStructType(definedStructs map[string]MethodIO, typeName string) bool {
+func isStructType(definedStructs map[string]common.MethodIO, typeName string) bool {
 	typeName = strings.TrimRight(typeName, "[]")
 	_, exists := definedStructs[typeName]
 	return exists

--- a/abis/helpers_test.go
+++ b/abis/helpers_test.go
@@ -1,4 +1,4 @@
-package solgo
+package abis
 
 import (
 	"testing"

--- a/abis/listener.go
+++ b/abis/listener.go
@@ -1,6 +1,7 @@
-package solgo
+package abis
 
 import (
+	"github.com/txpull/solgo/common"
 	"github.com/txpull/solgo/parser"
 	"go.uber.org/zap"
 )
@@ -17,8 +18,8 @@ type AbiListener struct {
 // It returns a pointer to the newly created AbiListener.
 func NewAbiListener() *AbiListener {
 	return &AbiListener{parser: &AbiParser{
-		abi:            ABI{},
-		definedStructs: make(map[string]MethodIO),
+		abi:            common.ABI{},
+		definedStructs: make(map[string]common.MethodIO),
 		definedEnums:   make(map[string]bool), // map to keep track of defined enum types
 
 	}}

--- a/abis/listener_test.go
+++ b/abis/listener_test.go
@@ -1,4 +1,4 @@
-package solgo
+package abis
 
 import (
 	"context"
@@ -6,6 +6,8 @@ import (
 	"testing"
 
 	"github.com/stretchr/testify/assert"
+	"github.com/txpull/solgo"
+	"github.com/txpull/solgo/tests"
 	"go.uber.org/zap"
 	"go.uber.org/zap/zapcore"
 )
@@ -27,40 +29,40 @@ func TestAbiListener(t *testing.T) {
 	}{
 		{
 			name:     "Dummy Contract",
-			contract: ReadContractFileForTest(t, "Dummy").Content,
+			contract: tests.ReadContractFileForTest(t, "Dummy").Content,
 			expected: `[{"inputs":[],"outputs":[{"internalType":"uint256","name":"","type":"uint256"}],"name":"x","type":"function","stateMutability":"view"},{"inputs":[],"outputs":[{"internalType":"uint256","name":"","type":"uint256"}],"name":"y","type":"function","stateMutability":"view"},{"inputs":[{"internalType":"uint256","name":"_x","type":"uint256"},{"internalType":"uint256","name":"_y","type":"uint256"}],"type":"constructor"}]`,
 		},
 		{
 			name:     "ERC20 Token",
-			contract: ReadContractFileForTest(t, "ERC20_Token").Content,
+			contract: tests.ReadContractFileForTest(t, "ERC20_Token").Content,
 			expected: `[{"inputs":[],"outputs":[{"internalType":"bytes32","name":"","type":"bytes32"}],"name":"MINTER_ROLE","type":"function","stateMutability":"view"},{"inputs":[],"outputs":[{"internalType":"uint256","name":"","type":"uint256"}],"name":"subscriptionAmount","type":"function","stateMutability":"view"},{"inputs":[{"internalType":"address","name":"","type":"address"}],"outputs":[{"internalType":"uint256","name":"","type":"uint256"}],"name":"subscriptionBalance","type":"function","stateMutability":"view"},{"inputs":[{"internalType":"address","name":"","type":"address"}],"outputs":[{"internalType":"bool","name":"","type":"bool"}],"name":"isSubscribed","type":"function","stateMutability":"view"},{"inputs":[{"internalType":"address","name":"","type":"address"}],"outputs":[{"internalType":"uint256","name":"","type":"uint256"}],"name":"rewards","type":"function","stateMutability":"view"},{"inputs":[],"outputs":[{"internalType":"address[]","name":"","type":"address[]"}],"name":"rewardedUsers","type":"function","stateMutability":"view"},{"inputs":[{"internalType":"string","name":"name","type":"string"},{"internalType":"string","name":"symbol","type":"string"},{"internalType":"uint256","name":"initialSupply","type":"uint256"},{"internalType":"uint256","name":"_subscriptionAmount","type":"uint256"}],"outputs":[],"name":"initialize","type":"function","stateMutability":"nonpayable"},{"inputs":[],"outputs":[],"name":"pause","type":"function","stateMutability":"nonpayable"},{"inputs":[],"outputs":[],"name":"unpause","type":"function","stateMutability":"nonpayable"},{"inputs":[],"outputs":[],"name":"purchaseSubscription","type":"function","stateMutability":"nonpayable"},{"inputs":[],"outputs":[],"name":"cancelSubscription","type":"function","stateMutability":"nonpayable"},{"inputs":[{"internalType":"address","name":"user","type":"address"}],"outputs":[{"internalType":"bool","name":"","type":"bool"}],"name":"getSubscriptionStatus","type":"function","stateMutability":"view"},{"inputs":[{"internalType":"address","name":"user","type":"address"},{"internalType":"uint256","name":"amount","type":"uint256"}],"outputs":[],"name":"reward","type":"function","stateMutability":"nonpayable"},{"inputs":[{"internalType":"address","name":"user","type":"address"}],"outputs":[{"internalType":"uint256","name":"","type":"uint256"}],"name":"getRewards","type":"function","stateMutability":"view"},{"inputs":[],"outputs":[{"internalType":"address[]","name":"","type":"address[]"}],"name":"getRewardedUsers","type":"function","stateMutability":"view"},{"inputs":[{"internalType":"address","name":"from","type":"address"},{"internalType":"address","name":"to","type":"address"},{"internalType":"uint256","name":"amount","type":"uint256"}],"outputs":[],"name":"_beforeTokenTransfer","type":"function","stateMutability":"nonpayable"},{"inputs":[{"internalType":"uint256","name":"newAmount","type":"uint256"}],"outputs":[],"name":"updateSubscriptionAmount","type":"function","stateMutability":"nonpayable"},{"inputs":[{"internalType":"address","name":"to","type":"address"},{"internalType":"uint256","name":"amount","type":"uint256"}],"outputs":[],"name":"mint","type":"function","stateMutability":"nonpayable"},{"anonymous":false,"inputs":[{"indexed":true,"internalType":"address","name":"user","type":"address"},{"internalType":"uint256","name":"amount","type":"uint256"}],"name":"SubscriptionPurchased","type":"event"},{"anonymous":false,"inputs":[{"indexed":true,"internalType":"address","name":"user","type":"address"},{"internalType":"uint256","name":"amount","type":"uint256"}],"name":"SubscriptionCanceled","type":"event"},{"anonymous":false,"inputs":[{"indexed":true,"internalType":"address","name":"user","type":"address"},{"internalType":"uint256","name":"amount","type":"uint256"}],"name":"UserRewarded","type":"event"}]`,
 		},
 		{
 			name:     "Mappings",
-			contract: ReadContractFileForTest(t, "Mappings").Content,
+			contract: tests.ReadContractFileForTest(t, "Mappings").Content,
 			expected: `[{"inputs":[{"internalType":"address","name":"","type":"address"}],"outputs":[{"internalType":"uint256","name":"","type":"uint256"}],"name":"simpleMapping","type":"function","stateMutability":"view"},{"inputs":[{"internalType":"address","name":"","type":"address"},{"internalType":"address","name":"","type":"address"}],"outputs":[{"internalType":"uint256","name":"","type":"uint256"}],"name":"doubleMapping","type":"function","stateMutability":"view"},{"inputs":[{"internalType":"address","name":"","type":"address"},{"internalType":"address","name":"","type":"address"},{"internalType":"address","name":"","type":"address"}],"outputs":[{"internalType":"uint256","name":"","type":"uint256"}],"name":"tripleMapping","type":"function","stateMutability":"view"}]`,
 		},
 		{
 			name:     "Structs",
-			contract: ReadContractFileForTest(t, "Structs").Content,
+			contract: tests.ReadContractFileForTest(t, "Structs").Content,
 			expected: `[{"inputs":[{"internalType":"struct MyStructs.ClasicStruct","name":"ClasicStruct","type":"tuple","components":[{"internalType":"uint256","name":"one","type":"uint256"},{"internalType":"uint256","name":"two","type":"uint256"}]},{"internalType":"struct MyStructs.NestedStruct","name":"NestedStruct","type":"tuple","components":[{"internalType":"uint256","name":"one","type":"uint256"},{"internalType":"uint256","name":"two","type":"uint256"},{"internalType":"struct MyStructs.ClasicStruct","name":"myStruct","type":"tuple","components":[{"internalType":"uint256","name":"one","type":"uint256"},{"internalType":"uint256","name":"two","type":"uint256"}]}]},{"internalType":"uint256","name":"Integer","type":"uint256"}],"outputs":[{"internalType":"struct MyStructs.NestedStruct","name":"NestedStruct","type":"tuple","components":[{"internalType":"uint256","name":"one","type":"uint256"},{"internalType":"uint256","name":"two","type":"uint256"},{"internalType":"struct MyStructs.ClasicStruct","name":"myStruct","type":"tuple","components":[{"internalType":"uint256","name":"one","type":"uint256"},{"internalType":"uint256","name":"two","type":"uint256"}]}]}],"name":"nestedStructExample","type":"function","stateMutability":"pure"},{"inputs":[{"internalType":"struct MyStructs.StructWithArray","name":"StructWithArray","type":"tuple","components":[{"internalType":"uint256","name":"one","type":"uint256"},{"internalType":"uint256[]","name":"array","type":"uint256[]"}]}],"outputs":[],"name":"structWithArrayExample","type":"function","stateMutability":"pure"},{"inputs":[{"internalType":"struct MyStructs.StructWithNestedArray","name":"StructWithNestedArray","type":"tuple","components":[{"internalType":"uint256","name":"one","type":"uint256"},{"internalType":"struct MyStructs.ClasicStruct[]","name":"structArray","type":"tuple[]","components":[{"internalType":"uint256","name":"one","type":"uint256"},{"internalType":"uint256","name":"two","type":"uint256"}]}]}],"outputs":[],"name":"structWithNestedArrayExample","type":"function","stateMutability":"pure"}]`,
 		},
 		{
 			name:     "Enums",
-			contract: ReadContractFileForTest(t, "Enums").Content,
+			contract: tests.ReadContractFileForTest(t, "Enums").Content,
 			expected: `[{"inputs":[],"outputs":[{"internalType":"enum EnumContract.State","name":"","type":"uint8"}],"name":"state","type":"function","stateMutability":"view"},{"inputs":[],"type":"constructor"},{"inputs":[],"outputs":[{"internalType":"bool","name":"","type":"bool"}],"name":"isWaiting","type":"function","stateMutability":"view"},{"inputs":[],"outputs":[{"internalType":"bool","name":"","type":"bool"}],"name":"isReady","type":"function","stateMutability":"view"},{"inputs":[],"outputs":[{"internalType":"bool","name":"","type":"bool"}],"name":"isActive","type":"function","stateMutability":"view"},{"inputs":[],"outputs":[],"name":"makeReady","type":"function","stateMutability":"nonpayable"},{"inputs":[],"outputs":[],"name":"makeActive","type":"function","stateMutability":"nonpayable"},{"inputs":[],"outputs":[],"name":"reset","type":"function","stateMutability":"nonpayable"}]`,
 		},
 	}
 
 	for _, testCase := range testCases {
 		t.Run(testCase.name, func(t *testing.T) {
-			parser, err := New(context.TODO(), strings.NewReader(testCase.contract))
+			parser, err := solgo.New(context.TODO(), strings.NewReader(testCase.contract))
 			assert.NoError(t, err)
 			assert.NotNil(t, parser)
 
 			// Register the contract information listener
 			abiListener := NewAbiListener()
-			err = parser.RegisterListener(ListenerAbi, abiListener)
+			err = parser.RegisterListener(solgo.ListenerAbi, abiListener)
 			assert.NoError(t, err)
 
 			syntaxErrs := parser.Parse()

--- a/common/types.go
+++ b/common/types.go
@@ -1,4 +1,4 @@
-package solgo
+package common
 
 // ContractInfo contains information about a contract
 type ContractInfo struct {

--- a/contracts/contract_listener.go
+++ b/contracts/contract_listener.go
@@ -1,9 +1,10 @@
-package solgo
+package contracts
 
 import (
 	"strings"
 
 	"github.com/antlr4-go/antlr/v4"
+	"github.com/txpull/solgo/common"
 	"github.com/txpull/solgo/parser"
 )
 
@@ -15,14 +16,14 @@ import (
 type ContractListener struct {
 	*parser.BaseSolidityParserListener                        // BaseSolidityParserListener is the base listener from the Solidity parser.
 	parser                             *parser.SolidityParser // parser is the Solidity parser instance.
-	contractInfo                       ContractInfo           // contractInfo is the contract information extracted from the listener.
+	contractInfo                       common.ContractInfo    // contractInfo is the contract information extracted from the listener.
 }
 
 // NewContractListener creates a new ContractListener. It takes a SolidityParser as an argument.
 func NewContractListener(parser *parser.SolidityParser) *ContractListener {
 	return &ContractListener{
 		parser:       parser,
-		contractInfo: ContractInfo{},
+		contractInfo: common.ContractInfo{},
 	}
 }
 
@@ -109,7 +110,7 @@ func (l *ContractListener) GetComments() []string {
 
 // GetInfoForTests returns a map of all information extracted from the contract.
 // This is used for testing purposes only
-func (l *ContractListener) ToStruct() ContractInfo {
+func (l *ContractListener) ToStruct() common.ContractInfo {
 	return l.contractInfo
 }
 

--- a/contracts/contract_listener_test.go
+++ b/contracts/contract_listener_test.go
@@ -1,4 +1,4 @@
-package solgo
+package contracts
 
 import (
 	"context"
@@ -6,6 +6,9 @@ import (
 	"testing"
 
 	"github.com/stretchr/testify/assert"
+	"github.com/txpull/solgo"
+	"github.com/txpull/solgo/common"
+	"github.com/txpull/solgo/tests"
 	"go.uber.org/zap"
 	"go.uber.org/zap/zapcore"
 )
@@ -23,17 +26,17 @@ func TestContractListener(t *testing.T) {
 	testCases := []struct {
 		name     string
 		contract string
-		expected ContractInfo
+		expected common.ContractInfo
 	}{
 		{
 			name:     "Empty Contract",
-			contract: ReadContractFileForTest(t, "Empty").Content,
-			expected: ContractInfo{},
+			contract: tests.ReadContractFileForTest(t, "Empty").Content,
+			expected: common.ContractInfo{},
 		},
 		{
 			name:     "Dummy Contract",
-			contract: ReadContractFileForTest(t, "Dummy").Content,
-			expected: ContractInfo{
+			contract: tests.ReadContractFileForTest(t, "Dummy").Content,
+			expected: common.ContractInfo{
 				Comments: nil,
 				License:  "MIT",
 				Name:     "Dummy",
@@ -44,8 +47,8 @@ func TestContractListener(t *testing.T) {
 		},
 		{
 			name:     "OpenZeppelin ERC20",
-			contract: ReadContractFileForTest(t, "ERC20_Token").Content,
-			expected: ContractInfo{
+			contract: tests.ReadContractFileForTest(t, "ERC20_Token").Content,
+			expected: common.ContractInfo{
 				Comments: []string{
 					"// Rewards",
 					"// Allows users to purchase subscription using the token",
@@ -84,13 +87,13 @@ func TestContractListener(t *testing.T) {
 
 	for _, testCase := range testCases {
 		t.Run(testCase.name, func(t *testing.T) {
-			parser, err := New(context.TODO(), strings.NewReader(testCase.contract))
+			parser, err := solgo.New(context.TODO(), strings.NewReader(testCase.contract))
 			assert.NoError(t, err)
 			assert.NotNil(t, parser)
 
 			// Register the contract information listener
 			contractListener := NewContractListener(parser.GetParser())
-			err = parser.RegisterListener(ListenerContractInfo, contractListener)
+			err = parser.RegisterListener(solgo.ListenerContractInfo, contractListener)
 			assert.NoError(t, err)
 
 			syntaxErrs := parser.Parse()

--- a/contracts/doc.go
+++ b/contracts/doc.go
@@ -1,0 +1,15 @@
+// Package contracts provides a set of utilities and listeners for working with Solidity contracts.
+// It includes a ContractListener, which is a listener for the Solidity parser that extracts information
+// about contracts, such as the contract name, implemented interfaces, imported contracts, pragmas, and comments.
+// The ContractListener is designed to be used in conjunction with the Solidity parser to provide a convenient
+// interface for working with Solidity contracts.
+//
+// The ContractListener extracts information from Solidity contracts by traversing the Solidity parse tree
+// and capturing relevant information during the parsing process. It identifies pragma directives, import directives,
+// contract definitions, inheritance specifiers, using directives, and comments within the contract source code.
+// Additionally, it can detect SPDX license identifiers if present.
+//
+// The extracted contract information can be accessed using the provided getter methods, which return various aspects
+// of the contract, such as the contract name, implemented interfaces, imported contracts, pragmas, comments, and SPDX license.
+// The ContractListener also provides a convenience method, ToStruct, that returns a struct containing all the extracted information.
+package contracts

--- a/go.mod
+++ b/go.mod
@@ -15,6 +15,7 @@ require (
 	github.com/decred/dcrd/dcrec/secp256k1/v4 v4.0.1 // indirect
 	github.com/holiman/uint256 v1.2.2-0.20230321075855-87b91420868c // indirect
 	github.com/pmezard/go-difflib v1.0.0 // indirect
+	github.com/stretchr/objx v0.5.0 // indirect
 	go.uber.org/atomic v1.7.0 // indirect
 	go.uber.org/multierr v1.6.0 // indirect
 	golang.org/x/crypto v0.1.0 // indirect

--- a/go.sum
+++ b/go.sum
@@ -20,6 +20,7 @@ github.com/pmezard/go-difflib v1.0.0 h1:4DBwDE0NGyQoBHbLQYPwSUPoCMWR5BEzIk/f1lZb
 github.com/pmezard/go-difflib v1.0.0/go.mod h1:iKH77koFhYxTK1pcRnkKkqfTogsbg7gZNVY4sRDYZ/4=
 github.com/stretchr/objx v0.1.0/go.mod h1:HFkY916IF+rwdDfMAkV7OtwuqBVzrE8GR6GFx+wExME=
 github.com/stretchr/objx v0.4.0/go.mod h1:YvHI0jy2hoMjB+UWwv71VJQ9isScKT/TqJzVSSt89Yw=
+github.com/stretchr/objx v0.5.0 h1:1zr/of2m5FGMsad5YfcqgdqdWrIhu+EBEJRhR1U7z/c=
 github.com/stretchr/objx v0.5.0/go.mod h1:Yh+to48EsGEfYuaHDzXPcE3xhTkx73EhmCGUpEOglKo=
 github.com/stretchr/testify v1.3.0/go.mod h1:M5WIy9Dh21IEIfnGCwXGc5bZfKNJtfHm1UVUgZn+9EI=
 github.com/stretchr/testify v1.7.1/go.mod h1:6Fq8oRcR53rry900zMqJjRRixrwX3KX962/h/Wwjteg=

--- a/solgo_test.go
+++ b/solgo_test.go
@@ -1,0 +1,96 @@
+package solgo
+
+import (
+	"context"
+	"strings"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+)
+
+func TestNew(t *testing.T) {
+	ctx := context.Background()
+	input := strings.NewReader("contract Test {}")
+
+	solgo, err := New(ctx, input)
+	assert.NoError(t, err, "error creating SolGo instance")
+	assert.Equal(t, input, solgo.GetInput(), "input reader is not set correctly")
+	assert.NotNil(t, solgo.GetLexer(), "lexer is not initialized")
+	assert.NotNil(t, solgo.GetParser(), "parser is not initialized")
+}
+
+func TestParse(t *testing.T) {
+	ctx := context.Background()
+	input := strings.NewReader("contract Test {}")
+
+	solgo, err := New(ctx, input)
+	assert.NoError(t, err, "error creating SolGo instance")
+
+	errs := solgo.Parse()
+	assert.Empty(t, errs, "syntax errors encountered during parsing")
+}
+
+func TestParseWithError(t *testing.T) {
+	ctx := context.Background()
+	input := strings.NewReader("contract Test {")
+
+	solgo, err := New(ctx, input)
+	assert.NoError(t, err, "error creating SolGo instance")
+
+	errs := solgo.Parse()
+	assert.NotEmpty(t, errs, "expected syntax errors, but none were encountered")
+}
+
+func TestGetTree(t *testing.T) {
+	ctx := context.Background()
+	input := strings.NewReader("contract Test {}")
+
+	solgo, err := New(ctx, input)
+	assert.NoError(t, err, "error creating SolGo instance")
+
+	tree := solgo.GetTree()
+	assert.NotNil(t, tree, "parse tree is not generated")
+}
+
+func TestGetTokenStream(t *testing.T) {
+	ctx := context.Background()
+	input := strings.NewReader("contract Test {}")
+
+	solgo, err := New(ctx, input)
+	assert.NoError(t, err, "error creating SolGo instance")
+
+	tokenStream := solgo.GetTokenStream()
+	assert.NotNil(t, tokenStream, "token stream is not generated")
+}
+
+func TestGetInputStream(t *testing.T) {
+	ctx := context.Background()
+	input := strings.NewReader("contract Test {}")
+
+	solgo, err := New(ctx, input)
+	assert.NoError(t, err, "error creating SolGo instance")
+
+	inputStream := solgo.GetInputStream()
+	assert.NotNil(t, inputStream, "input stream is not generated")
+}
+
+func TestGetLexer(t *testing.T) {
+	ctx := context.Background()
+	input := strings.NewReader("contract Test {}")
+
+	solgo, err := New(ctx, input)
+	assert.NoError(t, err, "error creating SolGo instance")
+
+	lexer := solgo.GetLexer()
+	assert.NotNil(t, lexer, "lexer is not generated")
+}
+
+func TestGetInput(t *testing.T) {
+	ctx := context.Background()
+	input := strings.NewReader("contract Test {}")
+
+	solgo, err := New(ctx, input)
+	assert.NoError(t, err, "error creating SolGo instance")
+
+	assert.Equal(t, input, solgo.GetInput(), "input reader is not returned correctly")
+}

--- a/tests/helpers.go
+++ b/tests/helpers.go
@@ -1,4 +1,4 @@
-package solgo
+package tests
 
 import (
 	"os"
@@ -19,7 +19,7 @@ func ReadContractFileForTest(t *testing.T, name string) TestContract {
 	dir, err := os.Getwd()
 	assert.NoError(t, err)
 
-	contractsDir := filepath.Join(dir, "data", "tests")
+	contractsDir := filepath.Join(dir, "..", "data", "tests")
 	path := filepath.Join(contractsDir, name+".sol")
 
 	_, err = os.Stat(contractsDir)


### PR DESCRIPTION
Does not make sense that all of the go code is in the main path. Instead, I've built sub packages for now for contracts and abis. As well introduced common.

Abis is intentional as a lot of packages in go use "abi" package name so making it "abis" creates imports easier.