### PR TITLE
Contract package multi line comment support

### DIFF
--- a/contracts/contract_listener.go
+++ b/contracts/contract_listener.go
@@ -124,9 +124,18 @@ func (l *ContractListener) searchForCommentsAndLicenses() {
 		if token.GetTokenType() == parser.SolidityLexerLINE_COMMENT {
 			text := token.GetText()
 
-			if strings.HasPrefix(text, "// SPDX-License-Identifier:") ||
-				strings.HasPrefix(text, "/* SPDX-License-Identifier:") {
+			if strings.HasPrefix(text, "// SPDX-License-Identifier:") {
 				l.contractInfo.License = strings.TrimSpace(text[27:])
+			} else {
+				// It's a regular comment
+				l.contractInfo.Comments = append(l.contractInfo.Comments, text)
+			}
+		}
+		if token.GetTokenType() == parser.SolidityLexerCOMMENT {
+			text := token.GetText()
+
+			if strings.HasPrefix(text, "/* SPDX-License-Identifier:") {
+				l.contractInfo.License = strings.TrimSpace(text[27 : len(text)-2])
 			} else {
 				// It's a regular comment
 				l.contractInfo.Comments = append(l.contractInfo.Comments, text)

--- a/contracts/contract_listener_test.go
+++ b/contracts/contract_listener_test.go
@@ -37,9 +37,12 @@ func TestContractListener(t *testing.T) {
 			name:     "Dummy Contract",
 			contract: tests.ReadContractFileForTest(t, "Dummy").Content,
 			expected: common.ContractInfo{
-				Comments: nil,
-				License:  "MIT",
-				Name:     "Dummy",
+				Comments: []string{
+					"// Some additional comments that can be extracted",
+					"/** \n * Multi line comments\n * are supported as well\n*/",
+				},
+				License: "MIT",
+				Name:    "Dummy",
 				Pragmas: []string{
 					"solidity ^0.8.5",
 				},

--- a/data/tests/Dummy.sol
+++ b/data/tests/Dummy.sol
@@ -1,6 +1,13 @@
 // SPDX-License-Identifier: MIT
 pragma solidity ^0.8.5;
 
+// Some additional comments that can be extracted
+
+/** 
+ * Multi line comments
+ * are supported as well
+*/
+
 contract Dummy {
     uint256 public x;
     uint256 public y;

--- a/data/tests/ERC20_Token.sol
+++ b/data/tests/ERC20_Token.sol
@@ -1,6 +1,7 @@
 // SPDX-License-Identifier: MIT
 pragma solidity ^0.8.0;
 
+
 import "@openzeppelin/contracts-upgradeable/token/ERC20/ERC20Upgradeable.sol";
 import "@openzeppelin/contracts-upgradeable/access/AccessControlUpgradeable.sol";
 import "@openzeppelin/contracts-upgradeable/proxy/utils/Initializable.sol";


### PR DESCRIPTION
In the past multi line comments were not extracted when parsing contract. This is now fixed.

This ticket closes #4