### PR TITLE
Basic IsProxy() check for contract listener

### DIFF
--- a/contracts/contract_listener_test.go
+++ b/contracts/contract_listener_test.go
@@ -83,6 +83,8 @@ func TestContractListener(t *testing.T) {
 					"PausableUpgradeable",
 					"SafeERC20Upgradeable",
 				},
+				IsProxy:         true,
+				ProxyConfidence: 100,
 			},
 		},
 	}

--- a/contracts/contract_listener_test.go
+++ b/contracts/contract_listener_test.go
@@ -33,6 +33,75 @@ func TestContractListener(t *testing.T) {
 			expected: ContractInfo{},
 		},
 		{
+			name:     "Contract Without Interfaces",
+			contract: tests.ReadContractFileForTest(t, "NoInterfaces").Content,
+			expected: ContractInfo{
+				Name: "NoInterfaces",
+				Pragmas: []string{
+					"solidity ^0.8.5",
+				},
+				License: "MIT",
+			},
+		},
+		{
+			name:     "Contract Without Imports",
+			contract: tests.ReadContractFileForTest(t, "NoImports").Content,
+			expected: ContractInfo{
+				Name: "NoImports",
+				Pragmas: []string{
+					"solidity ^0.8.5",
+				},
+				License: "MIT",
+			},
+		},
+		{
+			name:     "Contract Without Pragmas",
+			contract: tests.ReadContractFileForTest(t, "NoPragmas").Content,
+			expected: ContractInfo{
+				Name:    "NoPragmas",
+				License: "MIT",
+			},
+		},
+		{
+			name:     "Contract With Single-Line Comment",
+			contract: tests.ReadContractFileForTest(t, "SingleLineComment").Content,
+			expected: ContractInfo{
+				Comments: []string{
+					"// This is a single-line comment",
+				},
+				Name: "SingleLineComment",
+				Pragmas: []string{
+					"solidity ^0.8.5",
+				},
+				License: "MIT",
+			},
+		},
+		{
+			name:     "Contract With Multi-Line Comment",
+			contract: tests.ReadContractFileForTest(t, "MultiLineComment").Content,
+			expected: ContractInfo{
+				Comments: []string{
+					"/* This is a\n multi-line comment */",
+				},
+				Name: "MultiLineComment",
+				Pragmas: []string{
+					"solidity ^0.8.5",
+				},
+				License: "MIT",
+			},
+		},
+		{
+			name:     "Contract With Different SPDX License Identifier",
+			contract: tests.ReadContractFileForTest(t, "DifferentLicense").Content,
+			expected: ContractInfo{
+				License: "GPL-3.0",
+				Name:    "DifferentLicense",
+				Pragmas: []string{
+					"solidity ^0.8.5",
+				},
+			},
+		},
+		{
 			name:     "Dummy Contract",
 			contract: tests.ReadContractFileForTest(t, "Dummy").Content,
 			expected: ContractInfo{

--- a/contracts/doc.go
+++ b/contracts/doc.go
@@ -10,6 +10,6 @@
 // Additionally, it can detect SPDX license identifiers if present.
 //
 // The extracted contract information can be accessed using the provided getter methods, which return various aspects
-// of the contract, such as the contract name, implemented interfaces, imported contracts, pragmas, comments, and SPDX license.
+// of the contract, such as the contract name, implemented interfaces, imported contracts, pragmas, comments, is proxy, and SPDX license.
 // The ContractListener also provides a convenience method, ToStruct, that returns a struct containing all the extracted information.
 package contracts

--- a/contracts/types.go
+++ b/contracts/types.go
@@ -2,10 +2,12 @@ package contracts
 
 // ContractInfo contains information about a contract
 type ContractInfo struct {
-	Comments   []string `json:"comments"`   // Comments associated with the contract
-	License    string   `json:"license"`    // License information of the contract
-	Pragmas    []string `json:"pragmas"`    // Pragmas specified in the contract
-	Imports    []string `json:"imports"`    // Imported dependencies of the contract
-	Name       string   `json:"name"`       // Name of the contract
-	Implements []string `json:"implements"` // Interfaces implemented by the contract
+	Comments        []string `json:"comments"`         // Comments associated with the contract
+	License         string   `json:"license"`          // License information of the contract
+	Pragmas         []string `json:"pragmas"`          // Pragmas specified in the contract
+	Imports         []string `json:"imports"`          // Imported dependencies of the contract
+	Name            string   `json:"name"`             // Name of the contract
+	Implements      []string `json:"implements"`       // Interfaces implemented by the contract
+	IsProxy         bool     `json:"is_proxy"`         // Whether the contract is a proxy
+	ProxyConfidence int16    `json:"proxy_confidence"` // Confidence in the proxy detection
 }

--- a/data/tests/DifferentLicense.sol
+++ b/data/tests/DifferentLicense.sol
@@ -1,0 +1,6 @@
+// SPDX-License-Identifier: GPL-3.0
+pragma solidity ^0.8.5;
+
+contract DifferentLicense {
+    uint256 public value;
+}

--- a/data/tests/MultiLineComment.sol
+++ b/data/tests/MultiLineComment.sol
@@ -1,0 +1,8 @@
+// SPDX-License-Identifier: MIT
+pragma solidity ^0.8.5;
+
+/* This is a
+ multi-line comment */
+contract MultiLineComment {
+    uint256 public value;
+}

--- a/data/tests/NoImports.sol
+++ b/data/tests/NoImports.sol
@@ -1,0 +1,6 @@
+// SPDX-License-Identifier: MIT
+pragma solidity ^0.8.5;
+
+contract NoImports {
+    uint256 public value;
+}

--- a/data/tests/NoInterfaces.sol
+++ b/data/tests/NoInterfaces.sol
@@ -1,0 +1,6 @@
+// SPDX-License-Identifier: MIT
+pragma solidity ^0.8.5;
+
+contract NoInterfaces {
+    uint256 public value;
+}

--- a/data/tests/NoPragmas.sol
+++ b/data/tests/NoPragmas.sol
@@ -1,0 +1,5 @@
+// SPDX-License-Identifier: MIT
+
+contract NoPragmas {
+    uint256 public value;
+}

--- a/data/tests/SingleLineComment.sol
+++ b/data/tests/SingleLineComment.sol
@@ -1,0 +1,7 @@
+// SPDX-License-Identifier: MIT
+pragma solidity ^0.8.5;
+
+// This is a single-line comment
+contract SingleLineComment {
+    uint256 public value;
+}


### PR DESCRIPTION
Currently we didn't have any type of check. Now we added some, with note that in the future we will need to check for if it's proxy on a bit more serious level. For now, it looks into openzeppelin/contracts-upgradeable as well as if there are delegate calls within fallback and receive functions. On top of that, looks for modifiers that contain proxy and state variables that are type of address.

Following PR closes: #25 