### PR TITLE
Contract listener now properly parses libraries, abstract, interfaces.

### DIFF
--- a/contracts/contract_listener.go
+++ b/contracts/contract_listener.go
@@ -63,7 +63,19 @@ func (l *ContractListener) EnterImportDirective(ctx *parser.ImportDirectiveConte
 // EnterContractDefinition is called when the parser enters a contract definition.
 // It extracts the contract name from the context and sets it to the contractName field.
 func (l *ContractListener) EnterContractDefinition(ctx *parser.ContractDefinitionContext) {
+	l.contractInfo.Name = ctx.Identifier().GetText()
+	l.contractInfo.IsContract = true
+	l.contractInfo.IsAbstract = ctx.Abstract() != nil
+}
+
+func (l *ContractListener) EnterInterfaceDefinition(ctx *parser.InterfaceDefinitionContext) {
 	l.contractInfo.Name = ctx.Identifier().GetText() // get the contract name
+	l.contractInfo.IsInterface = true
+}
+
+func (l *ContractListener) EnterLibraryDefinition(ctx *parser.LibraryDefinitionContext) {
+	l.contractInfo.Name = ctx.Identifier().GetText() // get the contract name
+	l.contractInfo.IsLibrary = true
 }
 
 // EnterInheritanceSpecifier is called when the parser enters an inheritance specifier.
@@ -186,6 +198,22 @@ func (l *ContractListener) GetIsProxy() bool {
 // GetProxyConfidence returns the confidence of the proxy detection algorithm.
 func (l *ContractListener) GetProxyConfidence() int16 {
 	return l.contractInfo.ProxyConfidence
+}
+
+func (l *ContractListener) IsContract() bool {
+	return l.contractInfo.IsContract
+}
+
+func (l *ContractListener) IsInterface() bool {
+	return l.contractInfo.IsInterface
+}
+
+func (l *ContractListener) IsLibrary() bool {
+	return l.contractInfo.IsLibrary
+}
+
+func (l *ContractListener) IsAbstract() bool {
+	return l.contractInfo.IsAbstract
 }
 
 // GetInfoForTests returns a map of all information extracted from the contract.

--- a/contracts/contract_listener_test.go
+++ b/contracts/contract_listener_test.go
@@ -40,7 +40,8 @@ func TestContractListener(t *testing.T) {
 				Pragmas: []string{
 					"solidity ^0.8.5",
 				},
-				License: "MIT",
+				License:    "MIT",
+				IsContract: true,
 			},
 		},
 		{
@@ -51,15 +52,17 @@ func TestContractListener(t *testing.T) {
 				Pragmas: []string{
 					"solidity ^0.8.5",
 				},
-				License: "MIT",
+				License:    "MIT",
+				IsContract: true,
 			},
 		},
 		{
 			name:     "Contract Without Pragmas",
 			contract: tests.ReadContractFileForTest(t, "NoPragmas").Content,
 			expected: ContractInfo{
-				Name:    "NoPragmas",
-				License: "MIT",
+				Name:       "NoPragmas",
+				License:    "MIT",
+				IsContract: true,
 			},
 		},
 		{
@@ -73,7 +76,8 @@ func TestContractListener(t *testing.T) {
 				Pragmas: []string{
 					"solidity ^0.8.5",
 				},
-				License: "MIT",
+				License:    "MIT",
+				IsContract: true,
 			},
 		},
 		{
@@ -87,7 +91,8 @@ func TestContractListener(t *testing.T) {
 				Pragmas: []string{
 					"solidity ^0.8.5",
 				},
-				License: "MIT",
+				License:    "MIT",
+				IsContract: true,
 			},
 		},
 		{
@@ -99,6 +104,7 @@ func TestContractListener(t *testing.T) {
 				Pragmas: []string{
 					"solidity ^0.8.5",
 				},
+				IsContract: true,
 			},
 		},
 		{
@@ -114,6 +120,7 @@ func TestContractListener(t *testing.T) {
 				Pragmas: []string{
 					"solidity ^0.8.5",
 				},
+				IsContract: true,
 			},
 		},
 		{
@@ -154,6 +161,10 @@ func TestContractListener(t *testing.T) {
 				},
 				IsProxy:         true,
 				ProxyConfidence: 100,
+				IsContract:      true,
+				IsInterface:     false,
+				IsAbstract:      false,
+				IsLibrary:       false,
 			},
 		},
 	}

--- a/contracts/types.go
+++ b/contracts/types.go
@@ -10,4 +10,8 @@ type ContractInfo struct {
 	Implements      []string `json:"implements"`       // Interfaces implemented by the contract
 	IsProxy         bool     `json:"is_proxy"`         // Whether the contract is a proxy
 	ProxyConfidence int16    `json:"proxy_confidence"` // Confidence in the proxy detection
+	IsContract      bool     `json:"is_contract"`      // Whether the contract is a contract
+	IsInterface     bool     `json:"is_interface"`     // Whether the contract is an interface
+	IsLibrary       bool     `json:"is_library"`       // Whether the contract is a library
+	IsAbstract      bool     `json:"is_abstract"`      // Whether the contract is abstract
 }

--- a/solgo.go
+++ b/solgo.go
@@ -8,7 +8,6 @@ import (
 	"github.com/antlr4-go/antlr/v4"
 	"github.com/txpull/solgo/parser"
 	"github.com/txpull/solgo/syntaxerrors"
-	"go.uber.org/zap"
 )
 
 // SolGo is a struct that encapsulates the functionality for parsing and analyzing Solidity contracts.
@@ -115,11 +114,7 @@ func (s *SolGo) Parse() []syntaxerrors.SyntaxError {
 	tree := s.GetTree()
 
 	// Walk the parse tree with all registered listeners
-	for name, listener := range s.GetAllListeners() {
-		zap.L().Debug(
-			"walking parse tree",
-			zap.String("listener", name.String()),
-		)
+	for _, listener := range s.GetAllListeners() {
 		antlr.ParseTreeWalkerDefault.Walk(listener, tree)
 	}
 


### PR DESCRIPTION
Until now, I haven't properly tested contract listener with large files that are stored in production. What I've realized is that we're not reporting contract names for libraries and interfaces. As well, we were missing if contract is abstract or not.

This PR resolves these issues.