### PR TITLE
Rename solgo.New() to solgo.NewParser()

### DIFF
--- a/abis/listener_test.go
+++ b/abis/listener_test.go
@@ -61,7 +61,7 @@ func TestAbiListener(t *testing.T) {
 
 	for _, testCase := range testCases {
 		t.Run(testCase.name, func(t *testing.T) {
-			parser, err := solgo.New(context.TODO(), strings.NewReader(testCase.contract))
+			parser, err := solgo.NewParser(context.TODO(), strings.NewReader(testCase.contract))
 			assert.NoError(t, err)
 			assert.NotNil(t, parser)
 

--- a/ast/builder_test.go
+++ b/ast/builder_test.go
@@ -46,7 +46,7 @@ func TestAstBuilder(t *testing.T) {
 
 	for _, testCase := range testCases {
 		t.Run(testCase.name, func(t *testing.T) {
-			parser, err := solgo.New(context.TODO(), strings.NewReader(testCase.contract))
+			parser, err := solgo.NewParser(context.TODO(), strings.NewReader(testCase.contract))
 			assert.NoError(t, err)
 			assert.NotNil(t, parser)
 

--- a/contracts/contract_listener_test.go
+++ b/contracts/contract_listener_test.go
@@ -171,7 +171,7 @@ func TestContractListener(t *testing.T) {
 
 	for _, testCase := range testCases {
 		t.Run(testCase.name, func(t *testing.T) {
-			parser, err := solgo.New(context.TODO(), strings.NewReader(testCase.contract))
+			parser, err := solgo.NewParser(context.TODO(), strings.NewReader(testCase.contract))
 			assert.NoError(t, err)
 			assert.NotNil(t, parser)
 

--- a/listeners.go
+++ b/listeners.go
@@ -23,7 +23,7 @@ func (l ListenerName) String() string {
 
 type listeners map[ListenerName]antlr.ParseTreeListener
 
-func (s *SolGo) RegisterListener(name ListenerName, listener antlr.ParseTreeListener) error {
+func (s *Parser) RegisterListener(name ListenerName, listener antlr.ParseTreeListener) error {
 	if s.IsListenerRegistered(name) {
 		return fmt.Errorf("listener %s already registered", name)
 	}
@@ -32,11 +32,11 @@ func (s *SolGo) RegisterListener(name ListenerName, listener antlr.ParseTreeList
 	return nil
 }
 
-func (s *SolGo) GetAllListeners() map[ListenerName]antlr.ParseTreeListener {
+func (s *Parser) GetAllListeners() map[ListenerName]antlr.ParseTreeListener {
 	return s.listeners
 }
 
-func (s *SolGo) GetListener(name ListenerName) (antlr.ParseTreeListener, error) {
+func (s *Parser) GetListener(name ListenerName) (antlr.ParseTreeListener, error) {
 	if !s.IsListenerRegistered(name) {
 		return nil, fmt.Errorf("listener %s not registered", name)
 	}
@@ -44,7 +44,7 @@ func (s *SolGo) GetListener(name ListenerName) (antlr.ParseTreeListener, error) 
 	return s.listeners[name], nil
 }
 
-func (s *SolGo) IsListenerRegistered(name ListenerName) bool {
+func (s *Parser) IsListenerRegistered(name ListenerName) bool {
 	_, ok := s.listeners[name]
 	return ok
 }

--- a/listeners_test.go
+++ b/listeners_test.go
@@ -18,7 +18,7 @@ func TestListenerGetterAndSetter(t *testing.T) {
 	input := strings.NewReader("contract Test {}")
 
 	// Test New
-	s, err := New(ctx, input)
+	s, err := NewParser(ctx, input)
 	assert.NoError(t, err)
 	assert.NotNil(t, s)
 	assert.Equal(t, input, s.GetInput())

--- a/parser.go
+++ b/parser.go
@@ -10,8 +10,8 @@ import (
 	"github.com/txpull/solgo/syntaxerrors"
 )
 
-// SolGo is a struct that encapsulates the functionality for parsing and analyzing Solidity contracts.
-type SolGo struct {
+// Parser is a struct that encapsulates the functionality for parsing and analyzing Solidity contracts.
+type Parser struct {
 	// ctx is the context in which SolGo operates. It can be used to control cancellation of parsing.
 	ctx context.Context
 	// inputRaw is the raw input reader from which the Solidity contract is read.
@@ -34,7 +34,7 @@ type SolGo struct {
 // New creates a new instance of SolGo.
 // It takes a context and an io.Reader from which the Solidity contract is read.
 // It initializes an input stream, lexer, token stream, and parser, and sets up error listeners.
-func New(ctx context.Context, input io.Reader) (*SolGo, error) {
+func NewParser(ctx context.Context, input io.Reader) (*Parser, error) {
 	ib, err := io.ReadAll(input)
 	if err != nil {
 		return nil, fmt.Errorf("error reading input: %w", err)
@@ -61,7 +61,7 @@ func New(ctx context.Context, input io.Reader) (*SolGo, error) {
 	// Create a new ContextualParser with the token stream and listener
 	contextualParser := syntaxerrors.NewContextualParser(stream, errListener)
 
-	return &SolGo{
+	return &Parser{
 		ctx:            ctx,
 		inputRaw:       input,
 		inputStream:    inputStream,
@@ -74,43 +74,43 @@ func New(ctx context.Context, input io.Reader) (*SolGo, error) {
 }
 
 // GetInput returns the raw input reader from which the Solidity contract is read.
-func (s *SolGo) GetInput() io.Reader {
+func (s *Parser) GetInput() io.Reader {
 	return s.inputRaw
 }
 
 // GetInputStream returns the ANTLR input stream which is used by the lexer.
-func (s *SolGo) GetInputStream() *antlr.InputStream {
+func (s *Parser) GetInputStream() *antlr.InputStream {
 	return s.inputStream
 }
 
 // GetLexer returns the Solidity lexer which tokenizes the input stream.
-func (s *SolGo) GetLexer() *parser.SolidityLexer {
+func (s *Parser) GetLexer() *parser.SolidityLexer {
 	return s.lexer
 }
 
 // GetTokenStream returns the stream of tokens produced by the lexer.
-func (s *SolGo) GetTokenStream() *antlr.CommonTokenStream {
+func (s *Parser) GetTokenStream() *antlr.CommonTokenStream {
 	return s.tokenStream
 }
 
 // GetParser returns the Solidity parser which parses the token stream.
-func (s *SolGo) GetParser() *parser.SolidityParser {
+func (s *Parser) GetParser() *parser.SolidityParser {
 	return s.solidityParser.SolidityParser
 }
 
 // GetContextualParser returns the ContextualParser which wraps the Solidity parser.
-func (s *SolGo) GetContextualParser() *syntaxerrors.ContextualParser {
+func (s *Parser) GetContextualParser() *syntaxerrors.ContextualParser {
 	return s.solidityParser
 }
 
 // GetTree returns the root of the parse tree that results from parsing the Solidity contract.
-func (s *SolGo) GetTree() antlr.ParseTree {
+func (s *Parser) GetTree() antlr.ParseTree {
 	return s.solidityParser.SourceUnit()
 }
 
 // Parse initiates the parsing process. It walks the parse tree with all registered listeners
 // and returns any syntax errors that were encountered during parsing.
-func (s *SolGo) Parse() []syntaxerrors.SyntaxError {
+func (s *Parser) Parse() []syntaxerrors.SyntaxError {
 	tree := s.GetTree()
 
 	// Walk the parse tree with all registered listeners

--- a/parser_test.go
+++ b/parser_test.go
@@ -14,7 +14,7 @@ func TestNew(t *testing.T) {
 	ctx := context.Background()
 	input := strings.NewReader("contract Test {}")
 
-	solgo, err := New(ctx, input)
+	solgo, err := NewParser(ctx, input)
 	assert.NoError(t, err, "error creating SolGo instance")
 	assert.Equal(t, input, solgo.GetInput(), "input reader is not set correctly")
 	assert.NotNil(t, solgo.GetLexer(), "lexer is not initialized")
@@ -25,7 +25,7 @@ func TestParse(t *testing.T) {
 	ctx := context.Background()
 	input := strings.NewReader("contract Test {}")
 
-	solgo, err := New(ctx, input)
+	solgo, err := NewParser(ctx, input)
 	assert.NoError(t, err, "error creating SolGo instance")
 
 	errs := solgo.Parse()
@@ -36,7 +36,7 @@ func TestParseWithError(t *testing.T) {
 	ctx := context.Background()
 	input := strings.NewReader("contract Test {")
 
-	solgo, err := New(ctx, input)
+	solgo, err := NewParser(ctx, input)
 	assert.NoError(t, err, "error creating SolGo instance")
 
 	errs := solgo.Parse()
@@ -47,7 +47,7 @@ func TestGetTree(t *testing.T) {
 	ctx := context.Background()
 	input := strings.NewReader("contract Test {}")
 
-	solgo, err := New(ctx, input)
+	solgo, err := NewParser(ctx, input)
 	assert.NoError(t, err, "error creating SolGo instance")
 
 	tree := solgo.GetTree()
@@ -58,7 +58,7 @@ func TestGetTokenStream(t *testing.T) {
 	ctx := context.Background()
 	input := strings.NewReader("contract Test {}")
 
-	solgo, err := New(ctx, input)
+	solgo, err := NewParser(ctx, input)
 	assert.NoError(t, err, "error creating SolGo instance")
 
 	tokenStream := solgo.GetTokenStream()
@@ -69,7 +69,7 @@ func TestGetInputStream(t *testing.T) {
 	ctx := context.Background()
 	input := strings.NewReader("contract Test {}")
 
-	solgo, err := New(ctx, input)
+	solgo, err := NewParser(ctx, input)
 	assert.NoError(t, err, "error creating SolGo instance")
 
 	inputStream := solgo.GetInputStream()
@@ -80,7 +80,7 @@ func TestGetLexer(t *testing.T) {
 	ctx := context.Background()
 	input := strings.NewReader("contract Test {}")
 
-	solgo, err := New(ctx, input)
+	solgo, err := NewParser(ctx, input)
 	assert.NoError(t, err, "error creating SolGo instance")
 
 	lexer := solgo.GetLexer()
@@ -91,7 +91,7 @@ func TestGetInput(t *testing.T) {
 	ctx := context.Background()
 	input := strings.NewReader("contract Test {}")
 
-	solgo, err := New(ctx, input)
+	solgo, err := NewParser(ctx, input)
 	assert.NoError(t, err, "error creating SolGo instance")
 
 	assert.Equal(t, input, solgo.GetInput(), "input reader is not returned correctly")
@@ -156,7 +156,7 @@ func TestNew_SyntaxErrors(t *testing.T) {
 	for _, tc := range testCases {
 		t.Run(tc.name, func(t *testing.T) {
 			// Create a new SolGo instance
-			solGo, err := New(context.Background(), strings.NewReader(tc.contract))
+			solGo, err := NewParser(context.Background(), strings.NewReader(tc.contract))
 			assert.NoError(t, err)
 			assert.NotNil(t, solGo)
 


### PR DESCRIPTION
Dropping SolGo struct in favor of Parser and doing cross refactoring to support new naming.