### PR TITLE
AST Tuple TypeDescription type randomization bug

### DIFF
--- a/ast/tuple.go
+++ b/ast/tuple.go
@@ -166,8 +166,6 @@ func (t *TupleExpression) Parse(
 	}
 
 	t.TypeDescription = t.buildTypeDescription()
-
-	t.dumpNode(t)
 	return t
 }
 

--- a/data/tests/ast/ERC20.solgo.ast.json
+++ b/data/tests/ast/ERC20.solgo.ast.json
@@ -363,7 +363,7 @@
                             }
                           ],
                           "type_description": {
-                            "type_identifier": "t_tuple$_t_bool$_t_uint256$",
+                            "type_identifier": "t_tuple_$_t_bool_$_t_uint256$",
                             "type_string": "tuple(bool,uint256)"
                           }
                         }
@@ -809,7 +809,7 @@
                             }
                           ],
                           "type_description": {
-                            "type_identifier": "t_tuple$_t_bool$_t_uint256$",
+                            "type_identifier": "t_tuple_$_t_bool_$_t_uint256$",
                             "type_string": "tuple(bool,uint256)"
                           }
                         }
@@ -1444,7 +1444,7 @@
                             }
                           ],
                           "type_description": {
-                            "type_identifier": "t_tuple$_t_bool$_t_uint256$",
+                            "type_identifier": "t_tuple_$_t_bool_$_t_uint256$",
                             "type_string": "tuple(bool,uint256)"
                           }
                         }
@@ -1892,8 +1892,8 @@
                             }
                           ],
                           "type_description": {
-                            "type_identifier": "t_tuple$_t_uint256$_t_bool$",
-                            "type_string": "tuple(uint256,bool)"
+                            "type_identifier": "t_tuple_$_t_bool_$_t_uint256$",
+                            "type_string": "tuple(bool,uint256)"
                           }
                         }
                       }
@@ -2340,7 +2340,7 @@
                             }
                           ],
                           "type_description": {
-                            "type_identifier": "t_tuple$_t_bool$_t_uint256$",
+                            "type_identifier": "t_tuple_$_t_bool_$_t_uint256$",
                             "type_string": "tuple(bool,uint256)"
                           }
                         }

--- a/data/tests/ast/ERC20.solgo.ast.proto.json
+++ b/data/tests/ast/ERC20.solgo.ast.proto.json
@@ -361,7 +361,7 @@
                                         "start": "971"
                                       },
                                       "typeDescription": {
-                                        "typeIdentifier": "t_tuple$_t_bool$_t_uint256$",
+                                        "typeIdentifier": "t_tuple_$_t_bool_$_t_uint256$",
                                         "typeString": "tuple(bool,uint256)"
                                       }
                                     }
@@ -379,7 +379,7 @@
                                     "start": "964"
                                   },
                                   "typeDescription": {
-                                    "typeIdentifier": "t_tuple$_t_bool$_t_uint256$",
+                                    "typeIdentifier": "t_tuple_$_t_bool_$_t_uint256$",
                                     "typeString": "tuple(bool,uint256)"
                                   }
                                 }
@@ -821,7 +821,7 @@
                                         "start": "1302"
                                       },
                                       "typeDescription": {
-                                        "typeIdentifier": "t_tuple$_t_bool$_t_uint256$",
+                                        "typeIdentifier": "t_tuple_$_t_bool_$_t_uint256$",
                                         "typeString": "tuple(bool,uint256)"
                                       }
                                     }
@@ -839,7 +839,7 @@
                                     "start": "1295"
                                   },
                                   "typeDescription": {
-                                    "typeIdentifier": "t_tuple$_t_bool$_t_uint256$",
+                                    "typeIdentifier": "t_tuple_$_t_bool_$_t_uint256$",
                                     "typeString": "tuple(bool,uint256)"
                                   }
                                 }
@@ -1489,7 +1489,7 @@
                                         "start": "1947"
                                       },
                                       "typeDescription": {
-                                        "typeIdentifier": "t_tuple$_t_bool$_t_uint256$",
+                                        "typeIdentifier": "t_tuple_$_t_bool_$_t_uint256$",
                                         "typeString": "tuple(bool,uint256)"
                                       }
                                     }
@@ -1507,7 +1507,7 @@
                                     "start": "1940"
                                   },
                                   "typeDescription": {
-                                    "typeIdentifier": "t_tuple$_t_bool$_t_uint256$",
+                                    "typeIdentifier": "t_tuple_$_t_bool_$_t_uint256$",
                                     "typeString": "tuple(bool,uint256)"
                                   }
                                 }
@@ -1951,8 +1951,8 @@
                                         "start": "2282"
                                       },
                                       "typeDescription": {
-                                        "typeIdentifier": "t_tuple$_t_uint256$_t_bool$",
-                                        "typeString": "tuple(uint256,bool)"
+                                        "typeIdentifier": "t_tuple_$_t_bool_$_t_uint256$",
+                                        "typeString": "tuple(bool,uint256)"
                                       }
                                     }
                                   },
@@ -1969,8 +1969,8 @@
                                     "start": "2275"
                                   },
                                   "typeDescription": {
-                                    "typeIdentifier": "t_tuple$_t_uint256$_t_bool$",
-                                    "typeString": "tuple(uint256,bool)"
+                                    "typeIdentifier": "t_tuple_$_t_bool_$_t_uint256$",
+                                    "typeString": "tuple(bool,uint256)"
                                   }
                                 }
                               }
@@ -2413,7 +2413,7 @@
                                         "start": "2631"
                                       },
                                       "typeDescription": {
-                                        "typeIdentifier": "t_tuple$_t_bool$_t_uint256$",
+                                        "typeIdentifier": "t_tuple_$_t_bool_$_t_uint256$",
                                         "typeString": "tuple(bool,uint256)"
                                       }
                                     }
@@ -2431,7 +2431,7 @@
                                     "start": "2624"
                                   },
                                   "typeDescription": {
-                                    "typeIdentifier": "t_tuple$_t_bool$_t_uint256$",
+                                    "typeIdentifier": "t_tuple_$_t_bool_$_t_uint256$",
                                     "typeString": "tuple(bool,uint256)"
                                   }
                                 }

--- a/data/tests/ast/SafeMath.solgo.ast.json
+++ b/data/tests/ast/SafeMath.solgo.ast.json
@@ -358,7 +358,7 @@
                         }
                       ],
                       "type_description": {
-                        "type_identifier": "t_tuple$_t_bool$_t_uint256$",
+                        "type_identifier": "t_tuple_$_t_bool_$_t_uint256$",
                         "type_string": "tuple(bool,uint256)"
                       }
                     }
@@ -804,7 +804,7 @@
                         }
                       ],
                       "type_description": {
-                        "type_identifier": "t_tuple$_t_bool$_t_uint256$",
+                        "type_identifier": "t_tuple_$_t_bool_$_t_uint256$",
                         "type_string": "tuple(bool,uint256)"
                       }
                     }
@@ -1439,7 +1439,7 @@
                         }
                       ],
                       "type_description": {
-                        "type_identifier": "t_tuple$_t_bool$_t_uint256$",
+                        "type_identifier": "t_tuple_$_t_bool_$_t_uint256$",
                         "type_string": "tuple(bool,uint256)"
                       }
                     }
@@ -1887,7 +1887,7 @@
                         }
                       ],
                       "type_description": {
-                        "type_identifier": "t_tuple$_t_bool$_t_uint256$",
+                        "type_identifier": "t_tuple_$_t_bool_$_t_uint256$",
                         "type_string": "tuple(bool,uint256)"
                       }
                     }
@@ -2335,8 +2335,8 @@
                         }
                       ],
                       "type_description": {
-                        "type_identifier": "t_tuple$_t_uint256$_t_bool$",
-                        "type_string": "tuple(uint256,bool)"
+                        "type_identifier": "t_tuple_$_t_bool_$_t_uint256$",
+                        "type_string": "tuple(bool,uint256)"
                       }
                     }
                   }

--- a/data/tests/ast/TokenSale.solgo.ast.json
+++ b/data/tests/ast/TokenSale.solgo.ast.json
@@ -1797,7 +1797,7 @@
                             }
                           ],
                           "type_description": {
-                            "type_identifier": "t_tuple$_t_bool$_t_uint256$",
+                            "type_identifier": "t_tuple_$_t_bool_$_t_uint256$",
                             "type_string": "tuple(bool,uint256)"
                           }
                         }
@@ -2243,7 +2243,7 @@
                             }
                           ],
                           "type_description": {
-                            "type_identifier": "t_tuple$_t_bool$_t_uint256$",
+                            "type_identifier": "t_tuple_$_t_bool_$_t_uint256$",
                             "type_string": "tuple(bool,uint256)"
                           }
                         }
@@ -2878,7 +2878,7 @@
                             }
                           ],
                           "type_description": {
-                            "type_identifier": "t_tuple$_t_bool$_t_uint256$",
+                            "type_identifier": "t_tuple_$_t_bool_$_t_uint256$",
                             "type_string": "tuple(bool,uint256)"
                           }
                         }
@@ -3326,7 +3326,7 @@
                             }
                           ],
                           "type_description": {
-                            "type_identifier": "t_tuple$_t_bool$_t_uint256$",
+                            "type_identifier": "t_tuple_$_t_bool_$_t_uint256$",
                             "type_string": "tuple(bool,uint256)"
                           }
                         }
@@ -3774,8 +3774,8 @@
                             }
                           ],
                           "type_description": {
-                            "type_identifier": "t_tuple$_t_uint256$_t_bool$",
-                            "type_string": "tuple(uint256,bool)"
+                            "type_identifier": "t_tuple_$_t_bool_$_t_uint256$",
+                            "type_string": "tuple(bool,uint256)"
                           }
                         }
                       }

--- a/data/tests/ast/TokenSale.solgo.ast.proto.json
+++ b/data/tests/ast/TokenSale.solgo.ast.proto.json
@@ -1832,7 +1832,7 @@
                                         "start": "1667"
                                       },
                                       "typeDescription": {
-                                        "typeIdentifier": "t_tuple$_t_bool$_t_uint256$",
+                                        "typeIdentifier": "t_tuple_$_t_bool_$_t_uint256$",
                                         "typeString": "tuple(bool,uint256)"
                                       }
                                     }
@@ -1850,7 +1850,7 @@
                                     "start": "1660"
                                   },
                                   "typeDescription": {
-                                    "typeIdentifier": "t_tuple$_t_bool$_t_uint256$",
+                                    "typeIdentifier": "t_tuple_$_t_bool_$_t_uint256$",
                                     "typeString": "tuple(bool,uint256)"
                                   }
                                 }
@@ -2292,7 +2292,7 @@
                                         "start": "1998"
                                       },
                                       "typeDescription": {
-                                        "typeIdentifier": "t_tuple$_t_bool$_t_uint256$",
+                                        "typeIdentifier": "t_tuple_$_t_bool_$_t_uint256$",
                                         "typeString": "tuple(bool,uint256)"
                                       }
                                     }
@@ -2310,7 +2310,7 @@
                                     "start": "1991"
                                   },
                                   "typeDescription": {
-                                    "typeIdentifier": "t_tuple$_t_bool$_t_uint256$",
+                                    "typeIdentifier": "t_tuple_$_t_bool_$_t_uint256$",
                                     "typeString": "tuple(bool,uint256)"
                                   }
                                 }
@@ -2960,7 +2960,7 @@
                                         "start": "2643"
                                       },
                                       "typeDescription": {
-                                        "typeIdentifier": "t_tuple$_t_bool$_t_uint256$",
+                                        "typeIdentifier": "t_tuple_$_t_bool_$_t_uint256$",
                                         "typeString": "tuple(bool,uint256)"
                                       }
                                     }
@@ -2978,7 +2978,7 @@
                                     "start": "2636"
                                   },
                                   "typeDescription": {
-                                    "typeIdentifier": "t_tuple$_t_bool$_t_uint256$",
+                                    "typeIdentifier": "t_tuple_$_t_bool_$_t_uint256$",
                                     "typeString": "tuple(bool,uint256)"
                                   }
                                 }
@@ -3422,7 +3422,7 @@
                                         "start": "2978"
                                       },
                                       "typeDescription": {
-                                        "typeIdentifier": "t_tuple$_t_bool$_t_uint256$",
+                                        "typeIdentifier": "t_tuple_$_t_bool_$_t_uint256$",
                                         "typeString": "tuple(bool,uint256)"
                                       }
                                     }
@@ -3440,7 +3440,7 @@
                                     "start": "2971"
                                   },
                                   "typeDescription": {
-                                    "typeIdentifier": "t_tuple$_t_bool$_t_uint256$",
+                                    "typeIdentifier": "t_tuple_$_t_bool_$_t_uint256$",
                                     "typeString": "tuple(bool,uint256)"
                                   }
                                 }
@@ -3884,8 +3884,8 @@
                                         "start": "3327"
                                       },
                                       "typeDescription": {
-                                        "typeIdentifier": "t_tuple$_t_uint256$_t_bool$",
-                                        "typeString": "tuple(uint256,bool)"
+                                        "typeIdentifier": "t_tuple_$_t_bool_$_t_uint256$",
+                                        "typeString": "tuple(bool,uint256)"
                                       }
                                     }
                                   },
@@ -3902,8 +3902,8 @@
                                     "start": "3320"
                                   },
                                   "typeDescription": {
-                                    "typeIdentifier": "t_tuple$_t_uint256$_t_bool$",
-                                    "typeString": "tuple(uint256,bool)"
+                                    "typeIdentifier": "t_tuple_$_t_bool_$_t_uint256$",
+                                    "typeString": "tuple(bool,uint256)"
                                   }
                                 }
                               }


### PR DESCRIPTION
While unit testing I've discovered that approach we currently had switches randomly argument types of Tuple TypeDescription. Following PR is fixing that bug to keep the consistency in!