### PR TITLE
Sources Protocol Buffers + minor updates

### DIFF
--- a/abi/builder.go
+++ b/abi/builder.go
@@ -15,7 +15,7 @@ import (
 // Builder facilitates the construction of Ethereum ABIs.
 type Builder struct {
 	ctx        context.Context // Context for the builder operations.
-	sources    solgo.Sources   // Source files to be processed.
+	sources    *solgo.Sources  // Source files to be processed.
 	parser     *ir.Builder     // Parser for the source code.
 	astBuilder *ast.ASTBuilder // AST Builder for generating AST from parsed source.
 	root       *Root           // Root of the generated ABI.
@@ -24,7 +24,7 @@ type Builder struct {
 
 // NewBuilderFromSources initializes a new ABI builder using the provided sources.
 // It sets up the necessary IR builder based on the given sources.
-func NewBuilderFromSources(ctx context.Context, sources solgo.Sources) (*Builder, error) {
+func NewBuilderFromSources(ctx context.Context, sources *solgo.Sources) (*Builder, error) {
 	parser, err := ir.NewBuilderFromSources(context.TODO(), sources)
 	if err != nil {
 		return nil, err
@@ -42,7 +42,7 @@ func NewBuilderFromSources(ctx context.Context, sources solgo.Sources) (*Builder
 }
 
 // GetSources returns the source files being processed.
-func (b *Builder) GetSources() solgo.Sources {
+func (b *Builder) GetSources() *solgo.Sources {
 	return b.sources
 }
 

--- a/abi/builder_test.go
+++ b/abi/builder_test.go
@@ -27,7 +27,7 @@ func TestBuilderFromSources(t *testing.T) {
 	testCases := []struct {
 		name                 string
 		outputPath           string
-		sources              solgo.Sources
+		sources              *solgo.Sources
 		expectedAbi          string
 		expectedProto        string
 		unresolvedReferences int64
@@ -35,7 +35,7 @@ func TestBuilderFromSources(t *testing.T) {
 		{
 			name:       "Empty Contract Test",
 			outputPath: "ast/",
-			sources: solgo.Sources{
+			sources: &solgo.Sources{
 				SourceUnits: []*solgo.SourceUnit{
 					{
 						Name:    "Empty",
@@ -54,7 +54,7 @@ func TestBuilderFromSources(t *testing.T) {
 		{
 			name:       "Simple Storage Contract Test",
 			outputPath: "ast/",
-			sources: solgo.Sources{
+			sources: &solgo.Sources{
 				SourceUnits: []*solgo.SourceUnit{
 					{
 						Name:    "MathLib",
@@ -78,7 +78,7 @@ func TestBuilderFromSources(t *testing.T) {
 		{
 			name:       "OpenZeppelin ERC20 Test",
 			outputPath: "ast/",
-			sources: solgo.Sources{
+			sources: &solgo.Sources{
 				SourceUnits: []*solgo.SourceUnit{
 					{
 						Name:    "SafeMath",
@@ -117,7 +117,7 @@ func TestBuilderFromSources(t *testing.T) {
 		{
 			name:       "Token Sale ERC20 Test",
 			outputPath: "ast/",
-			sources: solgo.Sources{
+			sources: &solgo.Sources{
 				SourceUnits: []*solgo.SourceUnit{
 					{
 						Name:    "TokenSale",
@@ -145,7 +145,7 @@ func TestBuilderFromSources(t *testing.T) {
 		{
 			name:       "Lottery Test",
 			outputPath: "ast/",
-			sources: solgo.Sources{
+			sources: &solgo.Sources{
 				SourceUnits: []*solgo.SourceUnit{
 					{
 						Name:    "Lottery",
@@ -163,7 +163,7 @@ func TestBuilderFromSources(t *testing.T) {
 		{
 			name:       "Cheelee Test", // Took this one as I could discover ipfs metadata :joy:
 			outputPath: "contracts/cheelee/",
-			sources: solgo.Sources{
+			sources: &solgo.Sources{
 				SourceUnits: []*solgo.SourceUnit{
 					{
 						Name:    "Import",

--- a/ast/builder.go
+++ b/ast/builder.go
@@ -15,7 +15,7 @@ type ASTBuilder struct {
 	*parser.BaseSolidityParserListener
 	resolver              *Resolver
 	tree                  *Tree
-	sources               solgo.Sources          // sources is the source code of the Solidity files.
+	sources               *solgo.Sources         // sources is the source code of the Solidity files.
 	parser                *parser.SolidityParser // parser is the Solidity parser instance.
 	nextID                int64                  // nextID is the next ID to assign to a node.
 	comments              []*Comment
@@ -32,7 +32,7 @@ type ASTBuilder struct {
 }
 
 // NewAstBuilder creates a new ASTBuilder with the provided Solidity parser and source code.
-func NewAstBuilder(parser *parser.SolidityParser, sources solgo.Sources) *ASTBuilder {
+func NewAstBuilder(parser *parser.SolidityParser, sources *solgo.Sources) *ASTBuilder {
 	builder := &ASTBuilder{
 		parser:      parser,
 		sources:     sources,

--- a/ast/builder_test.go
+++ b/ast/builder_test.go
@@ -25,7 +25,7 @@ func TestAstBuilderFromSourceAsString(t *testing.T) {
 	testCases := []struct {
 		name                 string
 		outputPath           string
-		sources              solgo.Sources
+		sources              *solgo.Sources
 		expectedAst          string
 		expectedProto        string
 		unresolvedReferences int64
@@ -33,7 +33,7 @@ func TestAstBuilderFromSourceAsString(t *testing.T) {
 		{
 			name:       "Empty Contract Test",
 			outputPath: "ast/",
-			sources: solgo.Sources{
+			sources: &solgo.Sources{
 				SourceUnits: []*solgo.SourceUnit{
 					{
 						Name:    "Empty",
@@ -51,7 +51,7 @@ func TestAstBuilderFromSourceAsString(t *testing.T) {
 		{
 			name:       "Simple Storage Contract Test",
 			outputPath: "ast/",
-			sources: solgo.Sources{
+			sources: &solgo.Sources{
 				SourceUnits: []*solgo.SourceUnit{
 					{
 						Name:    "MathLib",
@@ -74,7 +74,7 @@ func TestAstBuilderFromSourceAsString(t *testing.T) {
 		{
 			name:       "OpenZeppelin ERC20 Test",
 			outputPath: "ast/",
-			sources: solgo.Sources{
+			sources: &solgo.Sources{
 				SourceUnits: []*solgo.SourceUnit{
 					{
 						Name:    "SafeMath",
@@ -112,7 +112,7 @@ func TestAstBuilderFromSourceAsString(t *testing.T) {
 		{
 			name:       "Token With Reference Resolution",
 			outputPath: "ast/",
-			sources: solgo.Sources{
+			sources: &solgo.Sources{
 				SourceUnits: []*solgo.SourceUnit{
 					{
 						Name:    "Token",
@@ -130,7 +130,7 @@ func TestAstBuilderFromSourceAsString(t *testing.T) {
 		{
 			name:       "Token Sale ERC20 Test",
 			outputPath: "ast/",
-			sources: solgo.Sources{
+			sources: &solgo.Sources{
 				SourceUnits: []*solgo.SourceUnit{
 					{
 						Name:    "TokenSale",
@@ -158,7 +158,7 @@ func TestAstBuilderFromSourceAsString(t *testing.T) {
 		{
 			name:       "Lottery Test",
 			outputPath: "ast/",
-			sources: solgo.Sources{
+			sources: &solgo.Sources{
 				SourceUnits: []*solgo.SourceUnit{
 					{
 						Name:    "Lottery",
@@ -176,7 +176,7 @@ func TestAstBuilderFromSourceAsString(t *testing.T) {
 		{
 			name:       "Cheelee Test", // Took this one as I could discover ipfs metadata :joy:
 			outputPath: "contracts/cheelee/",
-			sources: solgo.Sources{
+			sources: &solgo.Sources{
 				SourceUnits: []*solgo.SourceUnit{
 					{
 						Name:    "Import",

--- a/ast/continue_test.go
+++ b/ast/continue_test.go
@@ -10,7 +10,7 @@ import (
 
 func TestContinueStatement(t *testing.T) {
 	// Initialize the ASTBuilder and ContinueStatement
-	b := NewAstBuilder(nil, solgo.Sources{})
+	b := NewAstBuilder(nil, &solgo.Sources{})
 	cs := NewContinueStatement(b)
 
 	// Define test cases

--- a/ast/reference_test.go
+++ b/ast/reference_test.go
@@ -23,13 +23,13 @@ func TestResolver(t *testing.T) {
 	// Define multiple test cases
 	testCases := []struct {
 		name                 string
-		sources              solgo.Sources
+		sources              *solgo.Sources
 		expected             string
 		unresolvedReferences int64
 	}{
 		{
 			name: "Test Case 1 - Simple Test Contract",
-			sources: solgo.Sources{
+			sources: &solgo.Sources{
 				SourceUnits: []*solgo.SourceUnit{
 					{
 						Name:    "TestContract",
@@ -44,7 +44,7 @@ func TestResolver(t *testing.T) {
 		},
 		{
 			name: "Test Case 2 - Contract with Inheritance",
-			sources: solgo.Sources{
+			sources: &solgo.Sources{
 				SourceUnits: []*solgo.SourceUnit{
 					{
 						Name:    "BaseContract",
@@ -64,7 +64,7 @@ func TestResolver(t *testing.T) {
 		},
 		{
 			name: "Test Case 3 - Contract with Library",
-			sources: solgo.Sources{
+			sources: &solgo.Sources{
 				SourceUnits: []*solgo.SourceUnit{
 					{
 						Name:    "SafeMath",
@@ -84,7 +84,7 @@ func TestResolver(t *testing.T) {
 		},
 		{
 			name: "Test Case 4 - Contract with Interface",
-			sources: solgo.Sources{
+			sources: &solgo.Sources{
 				SourceUnits: []*solgo.SourceUnit{
 					{
 						Name:    "IERC20",

--- a/ast/source_unit.go
+++ b/ast/source_unit.go
@@ -39,7 +39,7 @@ func NewSourceUnit[T any](builder *ASTBuilder, name string, license string) *Sou
 }
 
 // SetAbsolutePathFromSources sets the absolute path of the source unit from the provided sources.
-func (s *SourceUnit[T]) SetAbsolutePathFromSources(sources solgo.Sources) {
+func (s *SourceUnit[T]) SetAbsolutePathFromSources(sources *solgo.Sources) {
 	for _, unit := range sources.SourceUnits {
 		if unit.Name == s.Name {
 			s.AbsolutePath = unit.Path

--- a/detector/detector.go
+++ b/detector/detector.go
@@ -17,14 +17,14 @@ import (
 // Solidity source code. It encapsulates the context, sources, ABI builder, and solc compiler selector.
 type Detector struct {
 	ctx     context.Context // Context for the builder operations.
-	sources solgo.Sources   // Source files to be processed.
+	sources *solgo.Sources  // Source files to be processed.
 	builder *abi.Builder    // ABI builder for the source code.
 	solc    *solc.Select    // Solc selector for the solc compiler.
 }
 
 // NewDetectorFromSources initializes a new Detector instance using the provided sources.
 // It sets up the ABI builder and solc compiler selector which provide access to Global parser, AST and IR.
-func NewDetectorFromSources(ctx context.Context, sources solgo.Sources) (*Detector, error) {
+func NewDetectorFromSources(ctx context.Context, sources *solgo.Sources) (*Detector, error) {
 	if !eip.StandardsLoaded() {
 		if err := eip.LoadStandards(); err != nil {
 			return nil, err
@@ -55,7 +55,7 @@ func (d *Detector) GetContext() context.Context {
 }
 
 // GetSources returns the Solidity source files associated with the Detector.
-func (d *Detector) GetSources() solgo.Sources {
+func (d *Detector) GetSources() *solgo.Sources {
 	return d.sources
 }
 

--- a/detector/detector_test.go
+++ b/detector/detector_test.go
@@ -29,12 +29,12 @@ func TestDetectorFromSources(t *testing.T) {
 	// Define multiple test cases
 	testCases := []struct {
 		name       string
-		sources    solgo.Sources
+		sources    *solgo.Sources
 		opcodeTest bool
 	}{
 		{
 			name: "Empty Contract Test",
-			sources: solgo.Sources{
+			sources: &solgo.Sources{
 				SourceUnits: []*solgo.SourceUnit{
 					{
 						Name:    "Empty",
@@ -50,7 +50,7 @@ func TestDetectorFromSources(t *testing.T) {
 		},
 		{
 			name: "Simple Storage Contract Test",
-			sources: solgo.Sources{
+			sources: &solgo.Sources{
 				SourceUnits: []*solgo.SourceUnit{
 					{
 						Name:    "MathLib",
@@ -70,7 +70,7 @@ func TestDetectorFromSources(t *testing.T) {
 		},
 		{
 			name: "OpenZeppelin ERC20 Test",
-			sources: solgo.Sources{
+			sources: &solgo.Sources{
 				SourceUnits: []*solgo.SourceUnit{
 					{
 						Name:    "SafeMath",
@@ -105,7 +105,7 @@ func TestDetectorFromSources(t *testing.T) {
 		},
 		{
 			name: "Token Sale ERC20 Test",
-			sources: solgo.Sources{
+			sources: &solgo.Sources{
 				SourceUnits: []*solgo.SourceUnit{
 					{
 						Name:    "TokenSale",
@@ -129,7 +129,7 @@ func TestDetectorFromSources(t *testing.T) {
 		},
 		{
 			name: "Lottery Test",
-			sources: solgo.Sources{
+			sources: &solgo.Sources{
 				SourceUnits: []*solgo.SourceUnit{
 					{
 						Name:    "Lottery",
@@ -143,7 +143,7 @@ func TestDetectorFromSources(t *testing.T) {
 		},
 		{
 			name: "Cheelee Test", // Took this one as I could discover ipfs metadata :joy:
-			sources: solgo.Sources{
+			sources: &solgo.Sources{
 				SourceUnits: []*solgo.SourceUnit{
 					{
 						Name:    "Import",
@@ -230,7 +230,7 @@ func TestDetectorFromSources(t *testing.T) {
 			assert.IsType(t, &ast.ASTBuilder{}, detector.GetAST())
 			assert.IsType(t, &ir.Builder{}, detector.GetIR())
 			assert.IsType(t, &solgo.Parser{}, detector.GetParser())
-			assert.IsType(t, solgo.Sources{}, detector.GetSources())
+			assert.IsType(t, &solgo.Sources{}, detector.GetSources())
 			assert.IsType(t, &solc.Select{}, detector.GetSolc())
 
 			if testCase.opcodeTest {

--- a/go.mod
+++ b/go.mod
@@ -12,7 +12,7 @@ require (
 	github.com/ipfs/go-ipfs-api v0.6.0
 	github.com/mr-tron/base58 v1.2.0
 	github.com/stretchr/testify v1.8.4
-	github.com/txpull/protos v0.1.3
+	github.com/txpull/protos v0.1.4
 	go.uber.org/zap v1.24.0
 	google.golang.org/protobuf v1.31.0
 )
@@ -50,9 +50,13 @@ require (
 	go.uber.org/multierr v1.11.0 // indirect
 	golang.org/x/crypto v0.11.0 // indirect
 	golang.org/x/exp v0.0.0-20230713183714-613f0c0eb8a1 // indirect
+	golang.org/x/net v0.11.0 // indirect
 	golang.org/x/sys v0.10.0 // indirect
+	golang.org/x/text v0.11.0 // indirect
+	google.golang.org/genproto v0.0.0-20230731193218-e0aa005b6bdf // indirect
 	google.golang.org/genproto/googleapis/api v0.0.0-20230731193218-e0aa005b6bdf // indirect
 	google.golang.org/genproto/googleapis/rpc v0.0.0-20230731190214-cbb8c96f2d6d // indirect
+	google.golang.org/grpc v1.57.0 // indirect
 	gopkg.in/check.v1 v1.0.0-20201130134442-10cb98267c6c // indirect
 	gopkg.in/yaml.v3 v3.0.1 // indirect
 	lukechampine.com/blake3 v1.2.1 // indirect

--- a/go.sum
+++ b/go.sum
@@ -89,8 +89,8 @@ github.com/spaolacci/murmur3 v1.1.0 h1:7c1g84S4BPRrfL5Xrdp6fOJ206sU9y293DDHaoy0b
 github.com/spaolacci/murmur3 v1.1.0/go.mod h1:JwIasOWyU6f++ZhiEuf87xNszmSA2myDM2Kzu9HwQUA=
 github.com/stretchr/testify v1.8.4 h1:CcVxjf3Q8PM0mHUKJCdn+eZZtm5yQwehR5yeSVQQcUk=
 github.com/stretchr/testify v1.8.4/go.mod h1:sz/lmYIOXD/1dqDmKjjqLyZ2RngseejIcXlSw2iwfAo=
-github.com/txpull/protos v0.1.3 h1:eKd7JrI6SjyqSPa2oGO2BELGHU9T0FrCY5P6ZV123KM=
-github.com/txpull/protos v0.1.3/go.mod h1:t5JJHXY96/1ozyAwQouHFwjOLHa61b2MtNpf2wfAyG8=
+github.com/txpull/protos v0.1.4 h1:vRG7UJw/kkYBN8b66+7Jz2GwyNHRQBYRa7LmQKcWtP0=
+github.com/txpull/protos v0.1.4/go.mod h1:t5JJHXY96/1ozyAwQouHFwjOLHa61b2MtNpf2wfAyG8=
 github.com/whyrusleeping/tar-utils v0.0.0-20201201191210-20a61371de5b h1:wA3QeTsaAXybLL2kb2cKhCAQTHgYTMwuI8lBlJSv5V8=
 github.com/whyrusleeping/tar-utils v0.0.0-20201201191210-20a61371de5b/go.mod h1:xT1Y5p2JR2PfSZihE0s4mjdJaRGp1waCTf5JzhQLBck=
 github.com/x448/float16 v0.8.4 h1:qLwI1I70+NjRFUR3zs1JPUCgaCXSh3SW62uAKT1mSBM=
@@ -115,6 +115,8 @@ golang.org/x/net v0.0.0-20180724234803-3673e40ba225/go.mod h1:mL1N/T3taQHkDXs73r
 golang.org/x/net v0.0.0-20180826012351-8a410e7b638d/go.mod h1:mL1N/T3taQHkDXs73rZJwtUhF3w3ftmwwsq0BUmARs4=
 golang.org/x/net v0.0.0-20190213061140-3a22650c66bd/go.mod h1:mL1N/T3taQHkDXs73rZJwtUhF3w3ftmwwsq0BUmARs4=
 golang.org/x/net v0.0.0-20190311183353-d8887717615a/go.mod h1:t9HGtf8HONx5eT2rtn7q6eTqICYqUVnKs3thJo3Qplg=
+golang.org/x/net v0.11.0 h1:Gi2tvZIJyBtO9SDr1q9h5hEQCp/4L2RQ+ar0qjx2oNU=
+golang.org/x/net v0.11.0/go.mod h1:2L/ixqYpgIVXmeoSA/4Lu7BzTG4KIyPIryS4IsOd1oQ=
 golang.org/x/oauth2 v0.0.0-20180821212333-d2e6202438be/go.mod h1:N/0e6XlmueqKjAGxoOufVs8QHGRruUQn6yWY3a++T0U=
 golang.org/x/sync v0.0.0-20180314180146-1d60e4601c6f/go.mod h1:RxMgew5VJxzue5/jJTE5uejpjVlOe/izrB70Jof72aM=
 golang.org/x/sync v0.0.0-20181108010431-42b317875d0f/go.mod h1:RxMgew5VJxzue5/jJTE5uejpjVlOe/izrB70Jof72aM=
@@ -125,6 +127,8 @@ golang.org/x/sys v0.5.0/go.mod h1:oPkhp1MJrh7nUepCBck5+mAzfO9JrbApNNgaTdGDITg=
 golang.org/x/sys v0.10.0 h1:SqMFp9UcQJZa+pmYuAKjd9xq1f0j5rLcDIk0mj4qAsA=
 golang.org/x/sys v0.10.0/go.mod h1:oPkhp1MJrh7nUepCBck5+mAzfO9JrbApNNgaTdGDITg=
 golang.org/x/text v0.3.0/go.mod h1:NqM8EUOU14njkJ3fqMW+pc6Ldnwhi/IjpwHt7yyuwOQ=
+golang.org/x/text v0.11.0 h1:LAntKIrcmeSKERyiOh0XMV39LXS8IE9UL2yP7+f5ij4=
+golang.org/x/text v0.11.0/go.mod h1:TvPlkZtksWOMsz7fbANvkp4WM8x/WCo/om8BMLbz+aE=
 golang.org/x/tools v0.0.0-20190114222345-bf090417da8b/go.mod h1:n7NCudcB/nEzxVGmLbDWY5pfWTLqBcC2KZ6jyYvM4mQ=
 golang.org/x/tools v0.0.0-20190226205152-f727befe758c/go.mod h1:9Yl7xja0Znq3iFh3HoIrodX9oNMXvdceNzlUR8zjMvY=
 golang.org/x/tools v0.0.0-20190311212946-11955173bddd/go.mod h1:LCzVGOaR6xXOjkQ3onu1FJEFr0SW1gC7cKk1uF8kGRs=
@@ -134,6 +138,8 @@ google.golang.org/appengine v1.1.0/go.mod h1:EbEs0AVv82hx2wNQdGPgUI5lhzA/G0D9Ywl
 google.golang.org/appengine v1.4.0/go.mod h1:xpcJRLb0r/rnEns0DIKYYv+WjYCduHsrkT7/EB5XEv4=
 google.golang.org/genproto v0.0.0-20180817151627-c66870c02cf8/go.mod h1:JiN7NxoALGmiZfu7CAH4rXhgtRTLTxftemlI0sWmxmc=
 google.golang.org/genproto v0.0.0-20190819201941-24fa4b261c55/go.mod h1:DMBHOl98Agz4BDEuKkezgsaosCRResVns1a3J2ZsMNc=
+google.golang.org/genproto v0.0.0-20230731193218-e0aa005b6bdf h1:v5Cf4E9+6tawYrs/grq1q1hFpGtzlGFzgWHqwt6NFiU=
+google.golang.org/genproto v0.0.0-20230731193218-e0aa005b6bdf/go.mod h1:oH/ZOT02u4kWEp7oYBGYFFkCdKS/uYR9Z7+0/xuuFp8=
 google.golang.org/genproto/googleapis/api v0.0.0-20230731193218-e0aa005b6bdf h1:xkVZ5FdZJF4U82Q/JS+DcZA83s/GRVL+QrFMlexk9Yo=
 google.golang.org/genproto/googleapis/api v0.0.0-20230731193218-e0aa005b6bdf/go.mod h1:5DZzOUPCLYL3mNkQ0ms0F3EuUNZ7py1Bqeq6sxzI7/Q=
 google.golang.org/genproto/googleapis/rpc v0.0.0-20230731190214-cbb8c96f2d6d h1:pgIUhmqwKOUlnKna4r6amKdUngdL8DrkpFeV8+VBElY=
@@ -141,6 +147,8 @@ google.golang.org/genproto/googleapis/rpc v0.0.0-20230731190214-cbb8c96f2d6d/go.
 google.golang.org/grpc v1.19.0/go.mod h1:mqu4LbDTu4XGKhr4mRzUsmM4RtVoemTSY81AxZiDr8c=
 google.golang.org/grpc v1.23.0/go.mod h1:Y5yQAOtifL1yxbo5wqy6BxZv8vAUGQwXBOALyacEbxg=
 google.golang.org/grpc v1.25.1/go.mod h1:c3i+UQWmh7LiEpx4sFZnkU36qjEYZ0imhYfXVyQciAY=
+google.golang.org/grpc v1.57.0 h1:kfzNeI/klCGD2YPMUlaGNT3pxvYfga7smW3Vth8Zsiw=
+google.golang.org/grpc v1.57.0/go.mod h1:Sd+9RMTACXwmub0zcNY2c4arhtrbBYD1AUHI/dt16Mo=
 google.golang.org/protobuf v1.26.0-rc.1/go.mod h1:jlhhOSvTdKEhbULTjvd4ARK9grFBp09yW+WbY/TyQbw=
 google.golang.org/protobuf v1.26.0/go.mod h1:9q0QmTI4eRPtz6boOQmLYwt+qCgq0jsYwAQnmE0givc=
 google.golang.org/protobuf v1.31.0 h1:g0LDEJHgrBl9N9r17Ru3sqWhkIx2NB67okBHPwC7hs8=

--- a/ir/builder.go
+++ b/ir/builder.go
@@ -13,7 +13,7 @@ import (
 // Builder facilitates the creation of the IR from source code using solgo and AST tools.
 type Builder struct {
 	ctx        context.Context // Context for the builder operations.
-	sources    solgo.Sources   // Source files to be processed.
+	sources    *solgo.Sources  // Source files to be processed.
 	parser     *solgo.Parser   // Parser for the source code.
 	astBuilder *ast.ASTBuilder // AST Builder for generating AST from parsed source.
 	root       *RootSourceUnit // Root of the generated IR.
@@ -31,7 +31,7 @@ func NewBuilder(ctx context.Context, parser *solgo.Parser, astBuilder *ast.ASTBu
 
 // NewBuilderFromSources creates a new IR builder from given sources. It initializes
 // the necessary parser and AST builder from the provided sources.
-func NewBuilderFromSources(ctx context.Context, sources solgo.Sources) (*Builder, error) {
+func NewBuilderFromSources(ctx context.Context, sources *solgo.Sources) (*Builder, error) {
 	parser, err := solgo.NewParserFromSources(ctx, sources)
 	if err != nil {
 		return nil, err
@@ -68,7 +68,7 @@ func (b *Builder) GetAstBuilder() *ast.ASTBuilder {
 }
 
 // GetSources returns the source files being processed.
-func (b *Builder) GetSources() solgo.Sources {
+func (b *Builder) GetSources() *solgo.Sources {
 	return b.sources
 }
 

--- a/ir/builder_test.go
+++ b/ir/builder_test.go
@@ -25,7 +25,7 @@ func TestIrBuilderFromSources(t *testing.T) {
 	testCases := []struct {
 		name                 string
 		outputPath           string
-		sources              solgo.Sources
+		sources              *solgo.Sources
 		expectedAst          string
 		expectedProto        string
 		unresolvedReferences int64
@@ -33,7 +33,7 @@ func TestIrBuilderFromSources(t *testing.T) {
 		{
 			name:       "Empty Contract Test",
 			outputPath: "ast/",
-			sources: solgo.Sources{
+			sources: &solgo.Sources{
 				SourceUnits: []*solgo.SourceUnit{
 					{
 						Name:    "Empty",
@@ -52,7 +52,7 @@ func TestIrBuilderFromSources(t *testing.T) {
 		{
 			name:       "Simple Storage Contract Test",
 			outputPath: "ast/",
-			sources: solgo.Sources{
+			sources: &solgo.Sources{
 				SourceUnits: []*solgo.SourceUnit{
 					{
 						Name:    "MathLib",
@@ -76,7 +76,7 @@ func TestIrBuilderFromSources(t *testing.T) {
 		{
 			name:       "OpenZeppelin ERC20 Test",
 			outputPath: "ast/",
-			sources: solgo.Sources{
+			sources: &solgo.Sources{
 				SourceUnits: []*solgo.SourceUnit{
 					{
 						Name:    "SafeMath",
@@ -116,7 +116,7 @@ func TestIrBuilderFromSources(t *testing.T) {
 		{
 			name:       "Token Sale ERC20 Test",
 			outputPath: "ast/",
-			sources: solgo.Sources{
+			sources: &solgo.Sources{
 				SourceUnits: []*solgo.SourceUnit{
 					{
 						Name:    "TokenSale",
@@ -144,7 +144,7 @@ func TestIrBuilderFromSources(t *testing.T) {
 		{
 			name:       "Lottery Test",
 			outputPath: "ast/",
-			sources: solgo.Sources{
+			sources: &solgo.Sources{
 				SourceUnits: []*solgo.SourceUnit{
 					{
 						Name:    "Lottery",
@@ -162,7 +162,7 @@ func TestIrBuilderFromSources(t *testing.T) {
 		{
 			name:       "Cheelee Test", // Took this one as I could discover ipfs metadata :joy:
 			outputPath: "contracts/cheelee/",
-			sources: solgo.Sources{
+			sources: &solgo.Sources{
 				SourceUnits: []*solgo.SourceUnit{
 					{
 						Name:    "Import",

--- a/parser.go
+++ b/parser.go
@@ -15,7 +15,7 @@ type Parser struct {
 	// ctx is the context in which SolGo operates. It can be used to control cancellation of parsing.
 	ctx context.Context
 	// sources is a struct that contains the sources of the Solidity contract.
-	sources Sources
+	sources *Sources
 	// inputRaw is the raw input reader from which the Solidity contract is read.
 	inputRaw io.Reader
 	// inputStream is the ANTLR input stream which is used by the lexer.
@@ -78,7 +78,7 @@ func NewParser(ctx context.Context, input io.Reader) (*Parser, error) {
 // NewParserFromSources creates a new instance of parser from a reader.
 // It takes a context and an io.Reader from which the Solidity contract is read.
 // It initializes an input stream, lexer, token stream, and parser, and sets up error listeners.
-func NewParserFromSources(ctx context.Context, sources Sources) (*Parser, error) {
+func NewParserFromSources(ctx context.Context, sources *Sources) (*Parser, error) {
 	if err := sources.Prepare(); err != nil {
 		return nil, fmt.Errorf("error preparing sources: %w", err)
 	}
@@ -117,7 +117,8 @@ func NewParserFromSources(ctx context.Context, sources Sources) (*Parser, error)
 	}, nil
 }
 
-func (s *Parser) GetSources() Sources {
+// GetSources returns the sources of the Solidity contract.
+func (s *Parser) GetSources() *Sources {
 	return s.sources
 }
 

--- a/sources_test.go
+++ b/sources_test.go
@@ -62,6 +62,7 @@ func TestSources(t *testing.T) {
 			assert.Equal(t, testCase.expected, combinedSource)
 			//os.WriteFile(fmt.Sprintf("combined_%d.sol", i), []byte(combinedSource), 0755)
 			assert.Equal(t, testCase.expectedUnits, len(testCase.sources.SourceUnits))
+			assert.NotNil(t, testCase.sources.ToProto())
 		})
 	}
 }


### PR DESCRIPTION
Besides supporting protocol buffers with `ToProto()`, from now on everywhere sources should be passed via reference.