### PR TITLE
Cleanups, coverage increase and nil check improvements

### DIFF
--- a/audit/slither.go
+++ b/audit/slither.go
@@ -29,10 +29,6 @@ func NewSlither(ctx context.Context, config *Config) (*Slither, error) {
 		return nil, ErrTempDirNotSet
 	}
 
-	if !toReturn.IsInstalled() {
-		return nil, ErrSlitherNotInstalled
-	}
-
 	return toReturn, nil
 }
 

--- a/audit/slither_test.go
+++ b/audit/slither_test.go
@@ -270,6 +270,8 @@ func TestSlither(t *testing.T) {
 			assert.NoError(t, err)
 			assert.NotNil(t, slither)
 
+			assert.True(t, slither.IsInstalled())
+
 			version, err := slither.Version()
 			assert.NoError(t, err)
 			assert.NotEmpty(t, version)

--- a/detector/detector.go
+++ b/detector/detector.go
@@ -3,6 +3,7 @@ package detector
 import (
 	"context"
 	"encoding/hex"
+	"errors"
 	"os"
 
 	"github.com/txpull/solgo"
@@ -28,6 +29,10 @@ type Detector struct {
 // NewDetectorFromSources initializes a new Detector instance using the provided sources.
 // It sets up the ABI builder and solc compiler selector which provide access to Global parser, AST and IR.
 func NewDetectorFromSources(ctx context.Context, sources *solgo.Sources) (*Detector, error) {
+	if sources == nil {
+		return nil, errors.New("sources needed to initialize detector")
+	}
+
 	if !eip.StandardsLoaded() {
 		if err := eip.LoadStandards(); err != nil {
 			return nil, err

--- a/ir/builder.go
+++ b/ir/builder.go
@@ -3,6 +3,7 @@ package ir
 import (
 	"context"
 	"encoding/json"
+	"errors"
 
 	ir_pb "github.com/txpull/protos/dist/go/ir"
 	"github.com/txpull/solgo"
@@ -32,6 +33,10 @@ func NewBuilder(ctx context.Context, parser *solgo.Parser, astBuilder *ast.ASTBu
 // NewBuilderFromSources creates a new IR builder from given sources. It initializes
 // the necessary parser and AST builder from the provided sources.
 func NewBuilderFromSources(ctx context.Context, sources *solgo.Sources) (*Builder, error) {
+	if sources == nil {
+		return nil, errors.New("sources needed to initialize ir builder")
+	}
+
 	parser, err := solgo.NewParserFromSources(ctx, sources)
 	if err != nil {
 		return nil, err

--- a/parser_test.go
+++ b/parser_test.go
@@ -156,14 +156,17 @@ func TestNew_SyntaxErrors(t *testing.T) {
 	for _, tc := range testCases {
 		t.Run(tc.name, func(t *testing.T) {
 			// Create a new SolGo instance
-			solGo, err := NewParser(context.Background(), strings.NewReader(tc.contract))
+			parser, err := NewParser(context.Background(), strings.NewReader(tc.contract))
 			assert.NoError(t, err)
-			assert.NotNil(t, solGo)
+			assert.NotNil(t, parser)
 
-			syntaxErrors := solGo.Parse()
+			syntaxErrors := parser.Parse()
 
 			// Check that the syntax errors match the expected syntax errors
 			assert.Equal(t, tc.expected, syntaxErrors)
+			assert.IsType(t, []syntaxerrors.SyntaxError{}, syntaxErrors)
+			assert.IsType(t, &Sources{}, parser.GetSources())
+			assert.IsType(t, &syntaxerrors.ContextualParser{}, parser.GetContextualParser())
 		})
 	}
 }

--- a/sources_test.go
+++ b/sources_test.go
@@ -65,8 +65,11 @@ func TestSources(t *testing.T) {
 			assert.NotNil(t, testCase.sources.ToProto())
 			assert.NoError(t, testCase.sources.WriteToDir("./data/tests/sources/"))
 			assert.NoError(t, testCase.sources.TruncateDir("./data/tests/sources/"))
+			assert.True(t, testCase.sources.ArePrepared())
 			assert.True(t, testCase.sources.SourceUnitExistsIn(testCase.sources.SourceUnits[0].Name, testCase.sources.SourceUnits))
 			assert.True(t, testCase.sources.SourceUnitExists(testCase.sources.SourceUnits[0].Name))
+			assert.NotNil(t, testCase.sources.GetSourceUnitByName(testCase.sources.SourceUnits[0].Name))
+			assert.NotNil(t, testCase.sources.GetSourceUnitByPath(testCase.sources.SourceUnits[0].Path))
 		})
 	}
 }

--- a/syntaxerrors/syntax_errors_test.go
+++ b/syntaxerrors/syntax_errors_test.go
@@ -87,6 +87,14 @@ func TestSyntaxErrorListener(t *testing.T) {
 
 			// Check that the errors match the expected errors
 			assert.Equal(t, tc.expected, listener.Errors)
+
+			for _, err := range listener.Errors {
+				assert.Equal(t, err.Context, "SourceUnit")
+				assert.Equal(t, err.Severity.String(), SeverityError.String())
+				assert.Equal(t, err.Line > 0, true)
+				assert.Equal(t, err.Message != "", true)
+				assert.NotEmpty(t, err.Error())
+			}
 		})
 	}
 }


### PR DESCRIPTION
Pre release cleanups and improvements to overall code coverage + few important nil checkers...

Removal of IsInstalled() from NewAuditor() as basically it slows down the detector package for looking into the slither version. This method will need to be checked for sure, but where necessary (in implementation of detector or auditor).